### PR TITLE
CGRPOD-1762 Fix loader bar

### DIFF
--- a/src/core/loader/loader.js
+++ b/src/core/loader/loader.js
@@ -37,8 +37,8 @@ export class Loader extends Screen {
             this.load.json("achievements-data", "achievements/config.json");
         }
 
-        const masterPack = this.cache.json.get("asset-master-pack");
         const gamePacksToLoad = ["gel/gel-pack"].concat(getMissingPacks(masterPack, this.scene.manager.keys));
+        const masterPack = this.cache.json.get("asset-master-pack");
 
         this.load.addPack(masterPack);
         gamePacksToLoad.forEach(pack => this.load.pack(pack));


### PR DESCRIPTION
Using `load.addPack` after `load.pack()` causes assets to be added to the
loader queue after it has been started, which causes progress to jump
back as more assets are queued.

https://jira.dev.bbc.co.uk/browse/CGPROD-1762