### PR TITLE
CGRPOD-1762 Fix loader bar

### DIFF
--- a/src/core/loader/loader.js
+++ b/src/core/loader/loader.js
@@ -40,8 +40,8 @@ export class Loader extends Screen {
         const masterPack = this.cache.json.get("asset-master-pack");
         const gamePacksToLoad = ["gel/gel-pack"].concat(getMissingPacks(masterPack, this.scene.manager.keys));
 
-        this.load.addPack(masterPack);
         gamePacksToLoad.forEach(pack => this.load.pack(pack));
+        this.load.addPack(masterPack);
 
         this.add.image(0, 0, "loader.background");
         this.add.image(0, -150, "loader.title");


### PR DESCRIPTION
Using `load.pack()` after `load.addPack`   causes assets to be added to the
loader queue after it has been started, which causes progress to jump
back as more assets are queued.

https://jira.dev.bbc.co.uk/browse/CGPROD-1762