### PR TITLE
NOTICKET Mock gmi crash on IE11

### DIFF
--- a/dev/scripts/gmi.js
+++ b/dev/scripts/gmi.js
@@ -161,7 +161,7 @@ var GMI = function(options, embedVars, gameDir) {
             settingsForm.appendChild(settingsLabel);
             settingsForm.appendChild(settingsCloseButton);
 
-            settings.append(settingsForm);
+            settings.appendChild(settingsForm);
 
             settingsCheckbox.addEventListener("change", function(){
                 onSettingsChanged("settings-changed", settingsCheckbox.value);
@@ -197,7 +197,7 @@ var GMI = function(options, embedVars, gameDir) {
     var isAchieved = function(config, stored) {
         var hasProgress = Boolean(config && config.maxProgress);
         var fullProgress = Boolean(stored && config && stored.progress >= config.maxProgress);
-    
+
         return (stored && !hasProgress) || (hasProgress && fullProgress);
     };
 


### PR DESCRIPTION
![IE11](https://media.giphy.com/media/S3MdT0HozQ8Y8/giphy.gif)

Opening settings locally crashes on IE11

IE11 doesn't support append; only has appendChild.