### PR TITLE
[CGPROD-2044] Fix first tick delay on count up

### DIFF
--- a/src/components/results/results-countup.js
+++ b/src/components/results/results-countup.js
@@ -62,6 +62,7 @@ export class ResultsCountup extends Phaser.GameObjects.Text {
             callback: this.incrementCountByOne,
             callbackScope: this,
             repeat,
+            startAt: delay,
         });
     }
 }

--- a/test/components/results/results-countup.test.js
+++ b/test/components/results/results-countup.test.js
@@ -98,6 +98,7 @@ describe("ResultsCountup", () => {
             callback: resultsCountup.incrementCountByOne,
             callbackScope: resultsCountup,
             repeat: 9,
+            startAt: mockConfig.countupDuration / 9,
         });
     });
 


### PR DESCRIPTION
Fixes a bug where the first tick delay was actually startDelay + duration instead of being just startDelay.