### PR TITLE
CGPROD-2124 Dirty fix for progress bar progress

### DIFF
--- a/src/core/loader/loader.js
+++ b/src/core/loader/loader.js
@@ -26,6 +26,7 @@ export class Loader extends Screen {
         loadPack.path = gmi.gameDir + gmi.embedVars.configPath;
         super({ key: "loader", pack: loadPack });
         this._loadbar = undefined;
+        this._progress = 0;
     }
 
     getConfig() {
@@ -69,10 +70,12 @@ export class Loader extends Screen {
     }
 
     updateLoadBar = progress => {
-        this._loadbar.frame.cutWidth = this._loadbar.width * progress;
-        this._loadbar.frame.updateUVs();
-
-        if (window.__qaMode) {
+        if (progress >= this._progress) {
+            this._progress = progress;
+            this._loadbar.frame.cutWidth = this._loadbar.width * progress;
+            this._loadbar.frame.updateUVs();
+        }
+        if (window.__debug) {
             console.log("Loader progress:", progress); // eslint-disable-line no-console
         }
     };

--- a/test/core/loader/loader.test.js
+++ b/test/core/loader/loader.test.js
@@ -138,6 +138,15 @@ describe("Loader", () => {
             loader.updateLoadBar(progress);
             expect(mockImage.frame.cutWidth).toEqual(progress);
         });
+
+        test("does not update the loading bar fill when progress is backwards", () => {
+            const progress = 42;
+
+            loader.preload();
+            loader.updateLoadBar(progress);
+            loader.updateLoadBar(41);
+            expect(mockImage.frame.cutWidth).toEqual(progress);
+        });
     });
 
     describe("createBrandLogo method", () => {

--- a/test/core/loader/loader.test.js
+++ b/test/core/loader/loader.test.js
@@ -20,7 +20,7 @@ describe("Loader", () => {
     let mockMasterPack;
 
     beforeEach(() => {
-        global.window.__qaMode = undefined;
+        global.window.__debug = undefined;
         jest.spyOn(GameSound, "setButtonClickSound").mockImplementation(() => {});
         jest.spyOn(a11y, "destroy").mockImplementation(() => {});
 
@@ -235,14 +235,14 @@ describe("Loader", () => {
         });
     });
 
-    describe("qaMode", () => {
+    describe("debug mode", () => {
         beforeEach(() => {
             jest.spyOn(console, "log").mockImplementation(() => {});
             loader.preload();
         });
 
-        test("logs the progress to the console when qaMode is true", () => {
-            global.window.__qaMode = true;
+        test("logs the progress to the console when debug is true", () => {
+            global.window.__debug = true;
             loader.updateLoadBar("50");
             expect(console.log.mock.calls[0]).toEqual(["Loader progress:", "50"]); // eslint-disable-line no-console
         });


### PR DESCRIPTION
Progress bar update method moves backwards as assets are added to the
loader queue after progress is updated. Total assets in queue increases
faster than they are loaded.

This is a dirty fix to only increase the progress bar if the percentage
increases. This will add inaccuracy (slow phase) to the lower end of the
bar but will fix any backwards movement.

[|||.........................]
[|||||.......................]
[||||||||....................]
[||||||......................]
[||||........................]
[|||||||||...................]
[||||||||||||||.............]
[||||||||||||||||||.........]
[||||||||||||||||||||.......]
[|||||||||||||||||||||||....]
[|||||||||||||||||||||||||||]