### PR TITLE
[CGPROD-2045] Results screen onward journeys

### DIFF
--- a/src/components/game.js
+++ b/src/components/game.js
@@ -108,7 +108,7 @@ export class Game extends Screen {
         };
 
         const onGameComplete = () => {
-            markLevelAsComplete(this.transientData["level-select"].title);
+            markLevelAsComplete(this.transientData["level-select"].id);
             this.transientData.results = {
                 keys,
                 gems,
@@ -159,7 +159,7 @@ export class Game extends Screen {
         };
 
         this.add
-            .text(0, 200, `Character Selected: ${this.transientData["character-select"].title}`, {
+            .text(0, 200, `Character Selected: ${this.transientData["character-select"].id}`, {
                 font: "32px ReithSans",
                 fill: "#f6931e",
                 align: "center",

--- a/src/components/game.js
+++ b/src/components/game.js
@@ -6,6 +6,7 @@
 import { Screen } from "../core/screen.js";
 import { accessibilify } from "../core/accessibility/accessibilify.js";
 import { gmi } from "../core/gmi/gmi.js";
+import * as state from "../core/state.js";
 
 export class Game extends Screen {
     calculateAchievements(item, amount, keys) {
@@ -92,8 +93,29 @@ export class Game extends Screen {
             accessibilify(button);
         }, this);
 
+        const areAnyLevelsRemaining = () => {
+            const levels = state.states.get("levels").getAll();
+            return levels.some(level => level.state !== "completed");
+        };
+
+        const getNextLevel = () => {
+            const nextLevel = state.states.get("levels").get(this.transientData["level-select"].id + 1);
+            return nextLevel.id ? nextLevel : undefined;
+        };
+
+        const markLevelAsComplete = levelTitle => {
+            state.states.get("levels").set(levelTitle, "completed");
+        };
+
         const onGameComplete = () => {
-            this.transientData.results = { keys, gems, stars };
+            markLevelAsComplete(this.transientData["level-select"].title);
+            this.transientData.results = {
+                keys,
+                gems,
+                stars,
+                levelsRemaining: areAnyLevelsRemaining(),
+                nextLevelData: getNextLevel() ? { "level-select": getNextLevel() } : undefined,
+            };
             this.navigation.next();
         };
 
@@ -137,14 +159,14 @@ export class Game extends Screen {
         };
 
         this.add
-            .text(0, 200, `Character Selected: ${this.transientData["character-select"].choice.title}`, {
+            .text(0, 200, `Character Selected: ${this.transientData["character-select"].id}`, {
                 font: "32px ReithSans",
                 fill: "#f6931e",
                 align: "center",
             })
             .setOrigin(0.5);
         this.add
-            .text(0, 250, `Level Selected: ${this.transientData["level-select"].choice.title}`, {
+            .text(0, 250, `Level Selected: ${this.transientData["level-select"].id}`, {
                 font: "32px ReithSans",
                 fill: "#f6931e",
                 align: "center",

--- a/src/components/game.js
+++ b/src/components/game.js
@@ -159,7 +159,7 @@ export class Game extends Screen {
         };
 
         this.add
-            .text(0, 200, `Character Selected: ${this.transientData["character-select"].id}`, {
+            .text(0, 200, `Character Selected: ${this.transientData["character-select"].title}`, {
                 font: "32px ReithSans",
                 fill: "#f6931e",
                 align: "center",

--- a/src/components/results/results-screen.js
+++ b/src/components/results/results-screen.js
@@ -56,7 +56,8 @@ export class Results extends Screen {
 
     createButtons() {
         const achievements = this.context.config.theme.game.achievements ? ["achievementsSmall"] : [];
-        const restartOrPlayAgain = this.transientData[this.scene.key].levelsRemaining ? ["restart"] : ["playagain"];
+        const restartOrPlayAgain =
+            this.transientData[this.scene.key].levelsRemaining === false ? ["playagain"] : ["restart"];
         const buttons = ["pause", "continueGame"].concat(achievements, restartOrPlayAgain);
         this.setLayout(buttons);
     }

--- a/src/components/select/select-screen.js
+++ b/src/components/select/select-screen.js
@@ -91,7 +91,7 @@ export class Select extends Screen {
 
         //TODO  Stats Stuff will need adding back in, once we have the carousel back
         //TODO work out the correct key if "continue" is passed here when continue button used vs grid button
-        this.transientData[this.scene.key] = this.states.get(getTitle());
+        this.transientData[this.scene.key] = { id: getTitle() };
         this.navigation.next();
     };
 }

--- a/src/components/select/select-screen.js
+++ b/src/components/select/select-screen.js
@@ -91,7 +91,7 @@ export class Select extends Screen {
 
         //TODO  Stats Stuff will need adding back in, once we have the carousel back
         //TODO work out the correct key if "continue" is passed here when continue button used vs grid button
-        this.transientData[this.scene.key] = { choice: { title: getTitle.call(this.grid) } };
+        this.transientData[this.scene.key] = this.states.get(getTitle());
         this.navigation.next();
     };
 }

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -250,6 +250,19 @@ export const config = screen => {
                 gmi.sendStatsEvent(...params);
             },
         },
+        playagain: {
+            group: "bottomCenter",
+            title: "Restart",
+            key: "playagain",
+            ariaLabel: "Play Again",
+            order: 12,
+            id: "playagain",
+            channel: buttonsChannel(screen),
+            action: ({ screen }) => {
+                const params = pushLevelId(screen, ["level", "playagain"]);
+                gmi.sendStatsEvent(...params);
+            },
+        },
         continue: {
             group: "bottomCenter",
             title: "Continue",

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -252,7 +252,7 @@ export const config = screen => {
         },
         playagain: {
             group: "bottomCenter",
-            title: "Restart",
+            title: "Play Again",
             key: "playagain",
             ariaLabel: "Play Again",
             order: 12,

--- a/src/main.js
+++ b/src/main.js
@@ -83,7 +83,7 @@ const screenConfig = {
     results: {
         scene: Results,
         routes: {
-            next: "home",
+            continue: "level-select",
             game: "game",
             restart: "game",
             home: "home",

--- a/test/components/results/results-screen.test.js
+++ b/test/components/results/results-screen.test.js
@@ -44,7 +44,7 @@ describe("Results Screen", () => {
         };
         mockConfig = {
             theme: {
-                resultsScreen: {
+                results: {
                     backdrop: { key: "mockKey", alpha: 1 },
                     resultText: {
                         style: { font: "36px ReithSans" },
@@ -101,10 +101,10 @@ describe("Results Screen", () => {
             text: jest.fn(() => mockTextAdd),
         };
         resultsScreen.scene = {
-            key: "resultsScreen",
+            key: "results",
         };
         resultsScreen.navigation = {
-            next: jest.fn(),
+            continue: jest.fn(),
             game: jest.fn(),
         };
         resultsScreen.events = {
@@ -123,7 +123,7 @@ describe("Results Screen", () => {
 
         test("adds GEL buttons to layout", () => {
             resultsScreen.create();
-            const expectedButtons = ["pause", "restart", "continueGame"];
+            const expectedButtons = ["pause", "continueGame", "restart"];
             expect(resultsScreen.setLayout).toHaveBeenCalledWith(expectedButtons);
         });
 
@@ -156,14 +156,14 @@ describe("Results Screen", () => {
         });
 
         test("adds a backdrop image with specified properties when one is specified in config", () => {
-            mockConfig.theme.resultsScreen.backdrop.alpha = 0.5;
+            mockConfig.theme.results.backdrop.alpha = 0.5;
             resultsScreen.create();
             expect(resultsScreen.add.image).toHaveBeenCalledWith(0, 0, "mockKey");
             expect(mockImage.alpha).toEqual(0.5);
         });
 
         test("adds an image with a default alpha of 1 when no alpha is specified", () => {
-            mockConfig.theme.resultsScreen.backdrop.alpha = undefined;
+            mockConfig.theme.results.backdrop.alpha = undefined;
 
             resultsScreen.create();
             expect(resultsScreen.add.image).toHaveBeenCalledWith(0, 0, "mockKey");
@@ -238,7 +238,7 @@ describe("Results Screen", () => {
         });
 
         test("does not render image when no key is provided on the backdrop object", () => {
-            mockConfig.theme.resultsScreen.backdrop.key = undefined;
+            mockConfig.theme.results.backdrop.key = undefined;
             resultsScreen.create();
             expect(resultsScreen.add.image).not.toHaveBeenCalledWith(0, 0, "mockKey");
         });
@@ -254,7 +254,7 @@ describe("Results Screen", () => {
         test("adds the achievement button when theme flag is set", () => {
             resultsScreen.context.config.theme.game.achievements = true;
             resultsScreen.create();
-            const expectedButtons = ["pause", "restart", "continueGame", "achievementsSmall"];
+            const expectedButtons = ["pause", "continueGame", "achievementsSmall", "restart"];
             expect(resultsScreen.setLayout).toHaveBeenCalledWith(expectedButtons);
         });
 
@@ -306,7 +306,7 @@ describe("Results Screen", () => {
 
             test("navigates to the next screen when clicked", () => {
                 eventBus.subscribe.mock.calls[0][0].callback();
-                expect(resultsScreen.navigation.next).toHaveBeenCalled();
+                expect(resultsScreen.navigation.continue).toHaveBeenCalled();
             });
         });
 

--- a/test/components/results/results-screen.test.js
+++ b/test/components/results/results-screen.test.js
@@ -258,6 +258,13 @@ describe("Results Screen", () => {
             expect(resultsScreen.setLayout).toHaveBeenCalledWith(expectedButtons);
         });
 
+        test("adds the play again button when levelsRemaining set to false in transient data", () => {
+            mockTransientData.results = { levelsRemaining: false };
+            resultsScreen.create();
+            const expectedButtons = ["pause", "continueGame", "playagain"];
+            expect(resultsScreen.setLayout).toHaveBeenCalledWith(expectedButtons);
+        });
+
         test("adds a callback to unsubscribe from scale events on shutdown", () => {
             resultsScreen.create();
             expect(resultsScreen.events.once).toHaveBeenCalledWith("shutdown", expect.any(Function));
@@ -308,6 +315,14 @@ describe("Results Screen", () => {
                 eventBus.subscribe.mock.calls[0][0].callback();
                 expect(resultsScreen.navigation.continue).toHaveBeenCalled();
             });
+
+            test("navigates to the game screen when clicked and nextLevelData is provided", () => {
+                const mockSelectData = { select: { test: "mock" } };
+                mockTransientData.results = { nextLevelData: mockSelectData };
+                eventBus.subscribe.mock.calls[0][0].callback();
+                expect(resultsScreen.navigation.game).toHaveBeenCalled();
+                expect(resultsScreen.transientData.select).toBe(mockSelectData.select);
+            });
         });
 
         describe("the restart button", () => {
@@ -317,6 +332,17 @@ describe("Results Screen", () => {
 
             test("restarts the game and passes saved data through", () => {
                 eventBus.subscribe.mock.calls[1][0].callback();
+                expect(resultsScreen.navigation.game).toHaveBeenCalled();
+            });
+        });
+
+        describe("the play again button", () => {
+            test("adds a event subscription", () => {
+                expect(eventBus.subscribe.mock.calls[2][0].name).toBe("playagain");
+            });
+
+            test("restarts the game and passes saved data through", () => {
+                eventBus.subscribe.mock.calls[2][0].callback();
                 expect(resultsScreen.navigation.game).toHaveBeenCalled();
             });
         });

--- a/test/components/select/select-screen.test.js
+++ b/test/components/select/select-screen.test.js
@@ -21,7 +21,7 @@ jest.mock("../../../src/core/layout/layout.js", () => ({
 jest.mock("../../../src/core/state.js", () => ({
     create: jest.fn(() => ({
         getAll: jest.fn(() => []),
-        get: jest.fn(() => ({ state: "locked" })),
+        get: jest.fn(title => ({ state: "locked", title })),
     })),
 }));
 
@@ -279,7 +279,7 @@ describe("Select Screen", () => {
             selectScreen.create();
 
             eventBus.subscribe.mock.calls[0][0].callback();
-            expect(selectScreen.transientData["test-select"].choice.title).toBe("key1");
+            expect(selectScreen.transientData["test-select"].title).toBe("key1");
         });
     });
 

--- a/test/core/layout/gel-defaults.test.js
+++ b/test/core/layout/gel-defaults.test.js
@@ -305,6 +305,20 @@ describe("Layout - Gel Defaults", () => {
         });
     });
 
+    describe("Play Again Button Callback", () => {
+        test("sends a stat to the GMI", () => {
+            gel.config(mockCurrentScreen).playagain.action({ screen: mockCurrentScreen });
+            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("level", "playagain");
+        });
+
+        test("appends level id to stats if it exists", () => {
+            const testLevelId = "test level id";
+            mockCurrentScreen.context.transientData = { "level-select": { choice: { title: testLevelId } } };
+            gel.config(mockCurrentScreen).playagain.action({ screen: mockCurrentScreen });
+            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("level", "playagain", { source: testLevelId });
+        });
+    });
+
     describe("Continue Game Button Callback", () => {
         test("sends a stat to the GMI", () => {
             gel.config(mockCurrentScreen).continueGame.action({ screen: mockCurrentScreen });

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -5,8 +5,10 @@
  */
 import { gmi } from "../src/core/gmi/gmi.js";
 import { Game } from "../src/components/game";
+import * as state from "../src/core/state.js";
 
 jest.mock("../src/core/accessibility/accessibilify.js");
+jest.mock("../src/core/state.js");
 jest.mock("../src/core/gmi/gmi.js");
 
 describe("Game", () => {
@@ -43,6 +45,16 @@ describe("Game", () => {
     let mockImageOn;
 
     beforeEach(() => {
+        const mockState = {
+            getAll: jest.fn(() => []),
+            get: jest.fn(() => ({
+                id: 7,
+            })),
+            set: jest.fn(),
+        };
+        state.states = {
+            get: jest.fn(() => mockState),
+        };
         gmi.achievements = { set: jest.fn() };
 
         game = new Game();
@@ -77,8 +89,8 @@ describe("Game", () => {
         game.setLayout = jest.fn();
         game.navigation = { next: jest.fn() };
         game.transientData = {
-            "character-select": { choice: { title: "Kawabashi" } },
-            "level-select": { choice: { title: "Hard level" } },
+            "character-select": { id: "Kawabashi" },
+            "level-select": { id: "Hard level" },
         };
         game.cache = { json: { get: jest.fn(() => mockAchievements) } };
     });
@@ -143,7 +155,7 @@ describe("Game", () => {
         });
 
         test("displays the character selected", () => {
-            const expectedCharacter = `Character Selected: ${game.transientData["character-select"].choice.title}`;
+            const expectedCharacter = `Character Selected: ${game.transientData["character-select"].title}`;
             expect(game.add.text).toHaveBeenCalledWith(0, 200, expectedCharacter, {
                 font: "32px ReithSans",
                 fill: "#f6931e",
@@ -152,7 +164,7 @@ describe("Game", () => {
         });
 
         test("displays the level selected", () => {
-            const expectedLevel = `Level Selected: ${game.transientData["level-select"].choice.title}`;
+            const expectedLevel = `Level Selected: ${game.transientData["level-select"].id}`;
             expect(game.add.text).toHaveBeenCalledWith(0, 250, expectedLevel, {
                 font: "32px ReithSans",
                 fill: "#f6931e",
@@ -455,12 +467,24 @@ describe("Game", () => {
 
             test("saves data from the game when the continue button image is clicked", () => {
                 continueButtonClickedOn.mock.calls[0][1]();
-                expect(game.transientData.results).toEqual({ gems: 0, keys: 0, stars: 0 });
+                expect(game.transientData.results).toEqual({
+                    gems: 0,
+                    keys: 0,
+                    stars: 0,
+                    levelsRemaining: false,
+                    nextLevelData: { "level-select": { id: 7 } },
+                });
             });
 
             test("saves data from the game when the continue text is clicked", () => {
                 continueTextClickedOn.mock.calls[0][1]();
-                expect(game.transientData.results).toEqual({ gems: 0, keys: 0, stars: 0 });
+                expect(game.transientData.results).toEqual({
+                    gems: 0,
+                    keys: 0,
+                    stars: 0,
+                    levelsRemaining: false,
+                    nextLevelData: { "level-select": { id: 7 } },
+                });
             });
 
             test("navigates to the next screen when the continue button image is clicked", () => {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -72,7 +72,7 @@ describe("Main", () => {
             results: {
                 scene: Results,
                 routes: {
-                    next: "home",
+                    continue: "level-select",
                     game: "game",
                     restart: "game",
                     home: "home",

--- a/themes/default/config/level-select.json5
+++ b/themes/default/config/level-select.json5
@@ -2,6 +2,10 @@
     theme: {
         "level-select": {
             music: "loader.backgroundMusic",
+            storageKey: "levels",
+            states: {
+                completed: { overlayAsset: "character-select.complete", x: 65, y: 35, suffix: "completed" },
+            },
             title: {
                 image: {
                     imageId: "title",
@@ -20,19 +24,19 @@
             },
             choices: [
                 {
-                    id: "item1",
+                    id: 1,
                     key: "carousel1",
                     ariaLabel: "Level 1",
                     title: "Test Level 1",
                 },
                 {
-                    id: "item2",
+                    id: 2,
                     key: "carousel2",
                     ariaLabel: "Level 2",
                     title: "Test Level 2",
                 },
                 {
-                    id: "item3",
+                    id: 3,
                     key: "carousel3",
                     ariaLabel: "Level 3",
                     title: "Test Level 3",

--- a/themes/default/gel/gel-pack.json
+++ b/themes/default/gel/gel-pack.json
@@ -180,6 +180,18 @@
             },
             {
                 "type": "spritesheet",
+                "key": "playagain",
+                "url": "gel/desktop/play-again.png",
+                "frameConfig": {
+                    "frameWidth": 224,
+                    "frameHeight": 64,
+                    "frameMax": 2,
+                    "margin": 0,
+                    "spacing": 4
+                }
+            },
+            {
+                "type": "spritesheet",
                 "key": "previous",
                 "url": "gel/desktop/previous.png",
                 "frameConfig": {
@@ -382,6 +394,18 @@
                 "type": "spritesheet",
                 "key": "restart",
                 "url": "gel/mobile/restart.png",
+                "frameConfig": {
+                    "frameWidth": 152,
+                    "frameHeight": 42,
+                    "frameMax": 2,
+                    "margin": 0,
+                    "spacing": 4
+                }
+            },
+            {
+                "type": "spritesheet",
+                "key": "playagain",
+                "url": "gel/mobile/play-again.png",
                 "frameConfig": {
                     "frameWidth": 152,
                     "frameHeight": 42,


### PR DESCRIPTION
This is a bit annoying to implement as currently state can be any string - there are no special states. You can define a state to be anything.

The game is in charge of setting states by default - eg. when a game level is successfully completed, mark as complete. Or if something gets unlocked, mark as unlocked.

Therefore, I've said the game should handle what level to navigate to next too - they pass it to the results screen which sets the data if the player wishes to play the next level. They can check whether whatever's next is unlocked and playable.

That means that the game will also be in charge of notifying the results screen whether there are levels remaining, and what level it should navigate the user to next.