### PR TITLE
Cgprod 2082 button order

### DIFF
--- a/src/components/overlays/pause.js
+++ b/src/components/overlays/pause.js
@@ -16,6 +16,7 @@ export class Pause extends Screen {
 
     create() {
         this.add.image(0, 0, `${this.scene.key}.pauseBackground`);
+        this.add.image(0, -170, `${this.scene.key}.title`);
         const buttons = ["home", "audio", "settings", "pausePlay", "howToPlay"];
 
         const parentKey = this.context.parentScreens.slice(-1)[0].scene.key;
@@ -24,6 +25,5 @@ export class Pause extends Screen {
         const replayButton = showReplay ? ["pauseReplay"] : [];
 
         this.setLayout(buttons.concat(replayButton));
-        this.add.image(0, -170, `${this.scene.key}.title`);
     }
 }

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -173,7 +173,7 @@ export const config = screen => {
             title: "Play",
             key: "play",
             ariaLabel: "Play Game",
-            order: 8,
+            order: 9,
             id: "play",
             channel: buttonsChannel(screen),
             action: ({ screen }) => {


### PR DESCRIPTION
- Fixes order of play / replay _(play should be on the right)_
- Fixes draw order of title and buttons _(buttons should be on top)_
