### PR TITLE
CGPROD-2211: Pause Button Audio Bug

### DIFF
--- a/src/core/layout/gel-button.js
+++ b/src/core/layout/gel-button.js
@@ -60,6 +60,13 @@ export class GelButton extends Phaser.GameObjects.Container {
     };
 
     onPointerUp(config, screen) {
+        // Prevents button sounds from being paused by overlays (Pause Overlay specifically)
+        GameSound.Assets.buttonClick.once(Phaser.Sound.Events.PAUSE, () => {
+            GameSound.Assets.buttonClick.resume();
+        });
+
+        GameSound.Assets.buttonClick.play();
+
         const inputManager = this.scene.sys.game.input;
         inputManager.updateInputPlugins("", inputManager.pointers);
         publish(config, { screen })();
@@ -119,7 +126,6 @@ export class GelButton extends Phaser.GameObjects.Container {
 }
 
 const publish = (config, data) => () => {
-    GameSound.Assets.buttonClick.play();
     eventBus.publish({
         channel: config.channel,
         name: config.id,

--- a/test/core/layout/gel-button.test.js
+++ b/test/core/layout/gel-button.test.js
@@ -32,7 +32,11 @@ describe("Gel Button", () => {
         eventBus.publish = jest.fn();
         GameSound.Assets = {
             backgroundMusic: {},
-            buttonClick: { play: jest.fn() },
+            buttonClick: {
+                play: jest.fn(),
+                once: jest.fn(),
+                resume: jest.fn(),
+            },
         };
         mockSprite = {
             width: 100,
@@ -180,6 +184,21 @@ describe("Gel Button", () => {
                 "",
                 mockScene.sys.game.input.pointers,
             );
+        });
+
+        test("pointerup function calls play on button click sound", () => {
+            const gelButton = new GelButton(mockScene, mockX, mockY, mockConfig);
+            gelButton.onPointerUp(mockConfig, mockScene);
+            expect(GameSound.Assets.buttonClick.play).toHaveBeenCalled();
+        });
+
+        test("pointerup function calls once on button click to prevent pausing", () => {
+            const gelButton = new GelButton(mockScene, mockX, mockY, mockConfig);
+            gelButton.onPointerUp(mockConfig, mockScene);
+            expect(GameSound.Assets.buttonClick.once).toHaveBeenCalled();
+
+            GameSound.Assets.buttonClick.once.mock.calls[0][1]();
+            expect(GameSound.Assets.buttonClick.resume).toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
Prevents Gel Buttons audio from being paused.

The Pause overlay calls pauseAll. This causes audio triggered before opening the overlay to pause which was causing this bug.

PR sets up a callback to run once a pause event is called on the button, which then resumes the button click audio.