### PR TITLE
CGPROD-2228 Stop stats screen being set by overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | Stop stats screen from being set on overlays ||
 | | Adds assetPrefix to screens with override support in themes. | |
 | 3.0.0 | |
 | | Adds V2 select and result screens. | |

--- a/src/core/screen.js
+++ b/src/core/screen.js
@@ -59,8 +59,8 @@ export class Screen extends Phaser.Scene {
         if (this.scene.key !== "loader" && this.scene.key !== "boot") {
             this.setStatsScreen(this.scene.key);
 
-            const themeScreenConfig = this._data.config.theme[this.scene.key];
-            GameSound.setupScreenMusic(this.scene.scene, themeScreenConfig);
+            this.themeScreenConfig = this._data.config.theme[this.scene.key];
+            GameSound.setupScreenMusic(this.scene.scene, this.themeScreenConfig);
 
             debugMode() && debug.addEvents(this);
         }
@@ -73,7 +73,7 @@ export class Screen extends Phaser.Scene {
     }
 
     setStatsScreen(screen) {
-        if (!this._data.config.theme[this.scene.key].isOverlay) {
+        if (!this.themeScreenConfig.isOverlay) {
             gmi.setStatsScreen(screen);
         }
     }

--- a/src/core/screen.js
+++ b/src/core/screen.js
@@ -57,9 +57,8 @@ export class Screen extends Phaser.Scene {
         this.cameras.main.scrollY = -CAMERA_Y;
 
         if (this.scene.key !== "loader" && this.scene.key !== "boot") {
-            this.setStatsScreen(this.scene.key);
-
             this.themeScreenConfig = this._data.config.theme[this.scene.key];
+            this.setStatsScreen(this.scene.key);
             GameSound.setupScreenMusic(this.scene.scene, this.themeScreenConfig);
 
             debugMode() && debug.addEvents(this);

--- a/src/core/screen.js
+++ b/src/core/screen.js
@@ -57,7 +57,7 @@ export class Screen extends Phaser.Scene {
         this.cameras.main.scrollY = -CAMERA_Y;
 
         if (this.scene.key !== "loader" && this.scene.key !== "boot") {
-            gmi.setStatsScreen(this.scene.key);
+            this.setStatsScreen(this.scene.key);
 
             const themeScreenConfig = this._data.config.theme[this.scene.key];
             GameSound.setupScreenMusic(this.scene.scene, themeScreenConfig);
@@ -70,6 +70,12 @@ export class Screen extends Phaser.Scene {
         a11y.destroy();
 
         this._makeNavigation();
+    }
+
+    setStatsScreen(screen) {
+        if (!this._data.config.theme[this.scene.key].isOverlay) {
+            gmi.setStatsScreen(screen);
+        }
     }
 
     setData(newData) {

--- a/test/core/screen.test.js
+++ b/test/core/screen.test.js
@@ -341,6 +341,14 @@ describe("Screen", () => {
                 data: mockSettings.audio,
             });
         });
+
+        test("does not set the stats screen if the screen is an overlay", () => {
+            createScreen("screenKey");
+            mockData.config.theme["screenKey"] = { isOverlay: true };
+            screen.init(mockData);
+
+            expect(mockGmi.setStatsScreen).not.toHaveBeenCalled();
+        });
     });
 
     describe("data handling", () => {

--- a/test/core/screen.test.js
+++ b/test/core/screen.test.js
@@ -347,7 +347,7 @@ describe("Screen", () => {
             mockData.config.theme["screenKey"] = { isOverlay: false };
             screen.init(mockData);
 
-            expect(mockGmi.setStatsScreen).not.toHaveBeenCalled();
+            expect(mockGmi.setStatsScreen).toHaveBeenCalled();
         });
 
         test("does not set the stats screen if the screen is an overlay", () => {

--- a/test/core/screen.test.js
+++ b/test/core/screen.test.js
@@ -342,6 +342,14 @@ describe("Screen", () => {
             });
         });
 
+        test("sets the stats screen if the screen is not an overlay", () => {
+            createScreen("screenKey");
+            mockData.config.theme["screenKey"] = { isOverlay: false };
+            screen.init(mockData);
+
+            expect(mockGmi.setStatsScreen).not.toHaveBeenCalled();
+        });
+
         test("does not set the stats screen if the screen is an overlay", () => {
             createScreen("screenKey");
             mockData.config.theme["screenKey"] = { isOverlay: true };


### PR DESCRIPTION
Pause, settings, how to play and achievements overlays should not set
stat screen so that the stats placement entry reports the page which
called it.

https://jira.dev.bbc.co.uk/browse/CGPROD-2228