### PR TITLE
CGPROD-2228 Close overlay use class call of stats

### DIFF
--- a/src/core/screen.js
+++ b/src/core/screen.js
@@ -119,7 +119,7 @@ export class Screen extends Phaser.Scene {
         this._layout.makeAccessible();
         this.sys.accessibleButtons.forEach(button => a11y.addButton(button));
         a11y.reset();
-        gmi.setStatsScreen(this.scene.key);
+        this.setStatsScreen(this.scene.key);
 
         eventBus.publish({
             channel: settingsChannel,

--- a/test/core/screen.test.js
+++ b/test/core/screen.test.js
@@ -360,6 +360,16 @@ describe("Screen", () => {
 
             expect(mockGmi.setStatsScreen).not.toHaveBeenCalled();
         });
+
+        test("removing an overlay does not set stat screen back to an underlying overlay", () => {
+            const mockOverlay = { removeAll: jest.fn(), scene: { key: "overlay", stop: jest.fn() } };
+            createScreen("screenKey");
+            mockData.config.theme["screenKey"] = { isOverlay: true };
+            screen.init(mockData);
+            screen._onOverlayRemoved(mockOverlay);
+
+            expect(mockGmi.setStatsScreen).not.toHaveBeenCalled();
+        });
     });
 
     describe("data handling", () => {


### PR DESCRIPTION
Class call of setStatsScreen should be used on overlay close, rather
than ditrectly GMI. This fixes chained overlays from changing the stats
screen when their 'child' overlay is closed.

https://jira.dev.bbc.co.uk/browse/CGPROD-2228