### PR TITLE
Cgprod 2240 window events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | Disable Phaser window events to prevent click-through on achievements / settings ||
 | | Remove references to qa mode (now debug mode) ||
 | | Stop stats screen from being set on overlays ||
 | | Adds assetPrefix to screens with override support in themes. | |

--- a/src/core/startup.js
+++ b/src/core/startup.js
@@ -52,6 +52,9 @@ export function startup(screenConfig, settingsConfig = {}) {
         scale: {
             mode: Phaser.Scale.NONE,
         },
+        input: {
+            windowEvents: false,
+        },
         scene: scenes,
         plugins: {
             global: [

--- a/test/core/startup.test.js
+++ b/test/core/startup.test.js
@@ -170,6 +170,13 @@ describe("Startup", () => {
             const startupNoContainer = () => startup({});
             expect(startupNoContainer).toThrowError(`Container element "#some-id" not found`); // eslint-disable-line quotes
         });
+
+        test("disable's phaser's global window events (prevents clickthrough from achievements)", () => {
+            startup({});
+            const actualConfig = Phaser.Game.mock.calls[0][0];
+
+            expect(actualConfig.input.windowEvents).toBe(false);
+        });
     });
 
     describe("Hook errors", () => {


### PR DESCRIPTION
Disable Phaser window events to prevent clickthrough on achievements / settings