### PR TITLE
Noticket small desktop achievements button.

### DIFF
--- a/themes/default/gel/gel-pack.json
+++ b/themes/default/gel/gel-pack.json
@@ -34,7 +34,7 @@
                 "key": "achievements-small",
                 "url": "gel/desktop/achievements-small.png",
                 "frameConfig": {
-                    "frameWidth": 224,
+                    "frameWidth": 64,
                     "frameHeight": 64,
                     "frameMax": 2,
                     "margin": 0,


### PR DESCRIPTION
Fixes small achievement size button in desktop.

NB: theme 2 is currently broken in multiple ways andd will need looking at.