### PR TITLE
NOTICKET achievements debug

### DIFF
--- a/dev/scripts/gmi.js
+++ b/dev/scripts/gmi.js
@@ -264,7 +264,7 @@ var GMI = function(options, embedVars, gameDir) {
             var stored = globalSettings.achievements.find(function(unlocked) { return unlocked.key === config.key });
             return Object.assign(config, stored, { achieved: isAchieved(config, stored) });
         });
-        console.log(output);
+        debugMode && console.log(output);
         return output;
     };
     GMI.prototype.achievements.set = function(update) {

--- a/dev/scripts/gmi.js
+++ b/dev/scripts/gmi.js
@@ -284,7 +284,7 @@ var GMI = function(options, embedVars, gameDir) {
 
         save(stored, update);
 
-        console.log("NOTIFY: ", achievedOnUpdate, update.key);
+        debugMode && console.log("NOTIFY: ", achievedOnUpdate, update.key);
         return achievedOnUpdate;
     };
     GMI.prototype.gameLoaded = function() {};

--- a/dev/scripts/gmi.js
+++ b/dev/scripts/gmi.js
@@ -192,10 +192,10 @@ var GMI = function(options, embedVars, gameDir) {
     var save = function(stored, update) {
         if (!stored) {
             globalSettings.achievements.push(update);
-            console.log("CREATE LOCAL DATA:", update);
+            debugMode && console.log("CREATE LOCAL DATA:", update);
         } else {
             Object.assign(stored, update);
-            console.log("UPDATE LOCAL DATA: ", stored, " -- TO: ", update);
+            debugMode && console.log("UPDATE LOCAL DATA: ", stored, " -- TO: ", update);
         }
         GMI.prototype.setGameData("achievements", globalSettings.achievements);
     };

--- a/docs/development/achievements.md
+++ b/docs/development/achievements.md
@@ -82,3 +82,6 @@ The following theme files should not be edited. It is a requirement that they re
 * _themes/#####/gel/mobile/notification.png_
 * _themes/#####/gel/desktop/achievements.png_
 * _themes/#####/gel/mobile/achievements.png_
+
+##Debugging
+Adding the flag `&debug=true` to the end of the url when developing locally will make the fake dev gmi console log calls to `gmi.achievements init/get/set`.


### PR DESCRIPTION
Put achievements logging behind the debug flag as pollutes the console log in local development.