### PR TITLE
[CGPROD-2396] Enable pointerover/out events on disabled select items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "genie",
-    "version": "3.4.2",
+    "version": "3.4.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/components/select/select-screen.js
+++ b/src/components/select/select-screen.js
@@ -72,7 +72,7 @@ export class Select extends Screen {
             config.properties && Object.assign(button.sprite, config.properties);
 
             config.suffix && (button.config.ariaLabel = [button.config.ariaLabel, config.suffix].join(" "));
-            button.input.enabled = Boolean(config.enabled !== false);
+            config.enabled === false && button.off(Phaser.Input.Events.POINTER_UP);
             button.accessibleElement.update();
         }, this);
     }

--- a/test/components/select/select-screen.test.js
+++ b/test/components/select/select-screen.test.js
@@ -396,6 +396,62 @@ describe("Select Screen", () => {
             expect(selectScreen._cells[0].button.config.ariaLabel).toBe("testLabel testSuffix");
         });
 
+        test("turns off the pointer up event on the button if the button is not enabled", () => {
+            const mockCell = {
+                button: {
+                    config: { id: "id_one" },
+                    overlays: { set: jest.fn() },
+                    setImage: jest.fn(),
+                    input: {},
+                    off: jest.fn(),
+                    accessibleElement: {
+                        update: jest.fn(),
+                    },
+                },
+            };
+
+            selectScreen.create();
+
+            selectScreen._cells = [mockCell];
+            selectScreen.states.getAll = () => [{ id: "id_one", state: "locked" }];
+
+            selectScreen.context.theme.states = {
+                locked: { x: 10, y: 20, asset: "test_asset", enabled: false },
+            };
+
+            selectScreen.updateStates();
+
+            expect(selectScreen._cells[0].button.off).toHaveBeenCalledWith(Phaser.Input.Events.POINTER_UP);
+        });
+
+        test("does not turn off the pointer up event on the button if the button is enabled", () => {
+            const mockCell = {
+                button: {
+                    config: { id: "id_one" },
+                    overlays: { set: jest.fn() },
+                    setImage: jest.fn(),
+                    input: {},
+                    off: jest.fn(),
+                    accessibleElement: {
+                        update: jest.fn(),
+                    },
+                },
+            };
+
+            selectScreen.create();
+
+            selectScreen._cells = [mockCell];
+            selectScreen.states.getAll = () => [{ id: "id_one", state: "unlocked" }];
+
+            selectScreen.context.theme.states = {
+                unlocked: { x: 10, y: 20, asset: "test_asset", enabled: true },
+            };
+
+            selectScreen.updateStates();
+
+            expect(selectScreen._cells[0].button.off).not.toHaveBeenCalled();
+        });
+
         test("updates the image if an asset property is available in the config block", () => {
             const mockCell = {
                 button: {


### PR DESCRIPTION
Allows particle effects to hook into the pointerover/out events.
Makes way for allowing separate particle emitter config for the items "disabled" state on pointerover/out.