### PR TITLE
CDPROD-2045 Expose screen in debug mode

### DIFF
--- a/src/core/debug/debug.js
+++ b/src/core/debug/debug.js
@@ -69,6 +69,7 @@ function create() {
     this.layout && this.input.keyboard.addKey("e").on("up", makeToggle("buttons", this.layout.debug.buttons, this));
     this.input.keyboard.addKey("r").on("up", toggleCSS);
     this.navigation.debug && this.input.keyboard.addKey("t").on("up", this.navigation.debug.bind(this));
+    window.__debug.screen = this;
 }
 
 const shutdown = scene => {

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -279,7 +279,7 @@ export const config = screen => {
         playAgain: {
             group: "bottomCenter",
             title: "Play Again",
-            key: "restart",
+            key: "play-again",
             ariaLabel: "Play Again",
             order: 12,
             id: "restart",

--- a/test/core/debug/debug.test.js
+++ b/test/core/debug/debug.test.js
@@ -15,6 +15,7 @@ describe("Debug system", () => {
     let mockContainer;
 
     beforeEach(() => {
+        window.__debug = {};
         debugLayoutModule.debugLayout = jest.fn();
 
         mockOnUpEvent = jest.fn();
@@ -185,6 +186,14 @@ describe("Debug system", () => {
             createCallback.call(mockScreen);
 
             expect(mockScreen.add.text).toHaveBeenCalledWith(0, 0, "test-description", expect.any(Object));
+        });
+
+        test("adds screen to debug object", () => {
+            addEvents(mockScreen);
+            const createCallback = mockScreen.events.on.mock.calls[0][1];
+
+            createCallback.call(mockScreen);
+            expect(window.__debug.screen).toBe(mockScreen);
         });
     });
 


### PR DESCRIPTION
This allows for testing of screen based data and functions in the
workflow, when in debug mode.

- expose screen on window.__debug.screen
- fix asset key for 'Play again' button