### PR TITLE
[CGPROD-2402] Remove particle emitters on disabled select screen buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 | Version | Description |
 |---------|-------------|
-| | expose current screen in debug mode as window.__debug.screen. |
+| | Remove particle emitters on disabled select screen buttons. |
+| | Expose current screen in debug mode as window.__debug.screen. |
 | | Add optional level select button to pause screen. |
 | | Narrative screen component. |
 | | Add text to background items system. |

--- a/src/components/select/select-particles.js
+++ b/src/components/select/select-particles.js
@@ -7,7 +7,10 @@ import { gmi } from "../../core/gmi/gmi.js";
 
 const onPointerOut = (emitter, button) => button.on(Phaser.Input.Events.POINTER_OUT, () => emitter.stop());
 
+const isButtonEnabled = button => button.listeners(Phaser.Input.Events.POINTER_UP).length === 0;
+
 const createEmitter = (scene, button, config) => {
+    if (isButtonEnabled(button)) return;
     const emitter = scene.add
         .particles(config.assetKey)
         .createEmitter(scene.cache.json.get(config.emitterConfigKey))

--- a/test/components/select/select-particles.test.js
+++ b/test/components/select/select-particles.test.js
@@ -25,7 +25,7 @@ describe("Select Screen - Particles", () => {
             emitterConfigKey: "mock emitter config key",
         };
         mockLayoutRoot = { setDepth: jest.fn() };
-        mockButton = { on: jest.fn(), x: 23, y: 132 };
+        mockButton = { on: jest.fn(), x: 23, y: 132, listeners: jest.fn(() => ["mock listener"]) };
         mockCells = [{ button: mockButton }];
         mockEmitterConfig = {
             lifespan: 800,
@@ -79,6 +79,14 @@ describe("Select Screen - Particles", () => {
         expect(mockParticles.createEmitter).toHaveBeenCalledWith(mockEmitterConfig);
     });
 
+    test("does not create an emitter when pointer over event is fired and button is disabled", () => {
+        mockButton.listeners = jest.fn(() => []);
+        addHoverParticlesToCells(mockScene, mockCells, mockConfig, mockLayoutRoot);
+        mockButton.on.mock.calls[0][1]();
+        expect(mockButton.on.mock.calls[0][0]).toBe(Phaser.Input.Events.POINTER_OVER);
+        expect(mockParticles.createEmitter).not.toHaveBeenCalledWith(mockEmitterConfig);
+    });
+
     test("sets the position of the emitter to the position of the button when pointer over event is fired", () => {
         addHoverParticlesToCells(mockScene, mockCells, mockConfig, mockLayoutRoot);
         mockButton.on.mock.calls[0][1]();
@@ -93,6 +101,14 @@ describe("Select Screen - Particles", () => {
         expect(mockButton.on.mock.calls[1][0]).toBe(Phaser.Input.Events.POINTER_OUT);
         mockButton.on.mock.calls[1][1]();
         expect(mockEmitter.stop).toHaveBeenCalled();
+    });
+
+    test("does not add a pointer out event to the button when pointer over event is fired and button is disabled", () => {
+        mockButton.listeners = jest.fn(() => []);
+        addHoverParticlesToCells(mockScene, mockCells, mockConfig, mockLayoutRoot);
+        mockButton.on.mock.calls[0][1]();
+        expect(mockButton.on.mock.calls[0][0]).toBe(Phaser.Input.Events.POINTER_OVER);
+        expect(mockButton.on).toHaveBeenCalledTimes(1);
     });
 
     test("sets layoutRoot depth to 1 when config.onTop is undefined", () => {


### PR DESCRIPTION
Disabled buttons already have their POINTER_UP listeners removed - hence there is a listener count is 0 check.