### PR TITLE
Cgprod 2465 voice blocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | Fix issue with buttons not being clickable when ios voice enabled. |
 | | Add source to pause screen level select button. |
 | | Background music now configured via asset pack. |
 | | screen.context.theme now screen.config. |

--- a/src/core/accessibility/accessible-dom-element.js
+++ b/src/core/accessibility/accessible-dom-element.js
@@ -29,6 +29,7 @@ const assignEvents = (el, options) => {
     el.addEventListener("blur", options.onMouseOut);
 
     el.addEventListener("touchmove", e => e.preventDefault());
+    el.addEventListener("touchstart", () => {});
 
     if (options.interactive === false) {
         el.setAttribute("tabindex", "-1");

--- a/test/core/accessibility/accessible-dom-element.test.js
+++ b/test/core/accessibility/accessible-dom-element.test.js
@@ -154,6 +154,11 @@ describe("Accessible DOM Element", () => {
             expect(touchMoveEvent.preventDefault).toHaveBeenCalled();
         });
 
+        test("Adds noop touchstart function so ios voiceover double tap works.", () => {
+            accessibleDomElement(options);
+            expect(mockElement.addEventListener).toHaveBeenCalledWith("touchstart", expect.any(Function));
+        });
+
         test("returns a keyup function", () => {
             const mockElement = accessibleDomElement(options);
             const keyUpEvent = { key: "Enter" };

--- a/test/core/accessibility/accessible-dom-element.test.js
+++ b/test/core/accessibility/accessible-dom-element.test.js
@@ -156,6 +156,7 @@ describe("Accessible DOM Element", () => {
 
         test("Adds noop touchstart function so ios voiceover double tap works.", () => {
             accessibleDomElement(options);
+            expect(mockElement.addEventListener.mock.calls[6][1]()).not.toBeDefined();
             expect(mockElement.addEventListener).toHaveBeenCalledWith("touchstart", expect.any(Function));
         });
 


### PR DESCRIPTION
Add empty touchstart event listener to accessible dom elements so ios voiceover double tap works.