### PR TITLE
CGPROD-2459 Add source to pause level select btn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | Add source to pause screen level select button. |
 | | Background music now configured via asset pack. |
 | | screen.context.theme now screen.config. |
 | | Remove particle emitters on disabled select screen buttons. |

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -165,8 +165,9 @@ export const config = screen => {
             id: "levelselect",
             channel: buttonsChannel(screen),
             action: ({ screen }) => {
+                const params = pushLevelId(screen, ["levelselect", "click"]);
                 screen.navigate(screen.context.navigation["pause"].routes.select);
-                gmi.sendStatsEvent("pauseLevelSelect", "click");
+                gmi.sendStatsEvent(...params);
             },
         },
         play: {

--- a/test/core/layout/gel-defaults.test.js
+++ b/test/core/layout/gel-defaults.test.js
@@ -241,7 +241,13 @@ describe("Layout - Gel Defaults", () => {
     describe("Pause Level Select Button Callback", () => {
         test("sends a stat to the GMI", () => {
             gel.config(mockCurrentScreen).levelSelect.action({ screen: mockCurrentScreen });
-            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("pauseLevelSelect", "click");
+            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("levelselect", "click");
+        });
+        test("appends level id to stats if it exists", () => {
+            const testLevelId = "test level id";
+            mockCurrentScreen.context.transientData = { "level-select": { choice: { title: testLevelId } } };
+            gel.config(mockCurrentScreen).levelSelect.action({ screen: mockCurrentScreen });
+            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("levelselect", "click", { source: testLevelId });
         });
     });
 


### PR DESCRIPTION
Adds param to stat for the level select button on pause screen which
contains level ID.

https://jira.dev.bbc.co.uk/browse/CGPROD-2459