### PR TITLE
NOTICKET overlay stats screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | setStatsScreen now triggered for overlays. |
 | | Dont show level select button on pause screen when already on select screen. |
 | | Add achievements button to pause screen. |
 | | Skip audio exiting pause when over narrative screen. |

--- a/src/core/screen.js
+++ b/src/core/screen.js
@@ -91,9 +91,7 @@ export class Screen extends Phaser.Scene {
     }
 
     setStatsScreen(screen) {
-        if (!this.config.isOverlay) {
-            gmi.setStatsScreen(screen);
-        }
+        gmi.setStatsScreen(screen);
     }
 
     setData(newData) {

--- a/test/core/screen.test.js
+++ b/test/core/screen.test.js
@@ -363,22 +363,22 @@ describe("Screen", () => {
             expect(mockGmi.setStatsScreen).toHaveBeenCalled();
         });
 
-        test("does not set the stats screen if the screen is an overlay", () => {
+        test("Set the stats screen if the screen is an overlay", () => {
             createScreen("screenKey");
             mockData.config.theme["screenKey"] = { isOverlay: true };
             screen.init(mockData);
 
-            expect(mockGmi.setStatsScreen).not.toHaveBeenCalled();
+            expect(mockGmi.setStatsScreen).toHaveBeenCalledWith("screenKey");
         });
 
-        test("removing an overlay does not set stat screen back to an underlying overlay", () => {
+        test("removing an overlay set stat screen back to an underlying overlay", () => {
             const mockOverlay = { removeAll: jest.fn(), scene: { key: "overlay", stop: jest.fn() } };
             createScreen("screenKey");
             mockData.config.theme["screenKey"] = { isOverlay: true };
             screen.init(mockData);
             screen._onOverlayRemoved(mockOverlay);
 
-            expect(mockGmi.setStatsScreen).not.toHaveBeenCalled();
+            expect(mockGmi.setStatsScreen).toHaveBeenCalledWith("screenKey");
         });
     });
 


### PR DESCRIPTION
* Removes the code that stopped overlays calling set stats screen because it is now needed.