### PR TITLE
 CGPROD-2516_Narrative-skip-button-duplicate-click 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | Prevents duplicate stat firing on Narrative screen "skip" button. |
 | 3.7.0 ||
 | | Improved merging of global and scene plugins added via gameOptions in main.js. |
 | | setStatsScreen now triggered for overlays. |

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -204,7 +204,6 @@ export const config = screen => {
             id: "skip",
             channel: buttonsChannel(screen),
             action: ({ screen }) => {
-                gmi.sendStatsEvent("skip", "click");
                 screen.navigation.next();
             },
         },

--- a/test/core/layout/gel-defaults.test.js
+++ b/test/core/layout/gel-defaults.test.js
@@ -267,10 +267,6 @@ describe("Layout - Gel Defaults", () => {
             gel.config(mockCurrentScreen).skip.action({ screen: mockCurrentScreen });
         });
 
-        test("sends a stat to the GMI", () => {
-            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("skip", "click");
-        });
-
         test("navigates next", () => {
             expect(mockCurrentScreen.navigation.next).toHaveBeenCalled();
         });


### PR DESCRIPTION
Prevents duplicate stat firing on Narrative screen "skip" button.