### PR TITLE
NOTICKET State serialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | Force state to be serialised to an object and not an array when keys are numeric. |
 | | Make accessibility listener active to fix pause bug. |
 | | Update achievements docs. |
 | | Add build number to console banner. |

--- a/src/core/states.js
+++ b/src/core/states.js
@@ -26,7 +26,7 @@ export const initState = (stateKey, config) => {
     const getAll = fp.flow(getStored, getMerged);
 
     const set = (id, state = null) => {
-        gmi.setGameData("genie", fp.set([stateKey, id], { state }, getGenieStore()));
+        gmi.setGameData("genie", fp.setWith(Object, [stateKey, id], { state }, getGenieStore()));
     };
 
     const state = {

--- a/test/core/states.test.js
+++ b/test/core/states.test.js
@@ -59,6 +59,14 @@ describe("State", () => {
                 stateKey: { test_choice: { state: null } },
             });
         });
+
+        test("Always serialises to an object and not an array when numeric keys are used", () => {
+            const stateSet = initState("stateKey", []);
+            stateSet.set(2, "complete");
+
+            expect(mockGmi.setGameData.mock.calls[0][1].stateKey).toStrictEqual(expect.any(Object));
+            expect(mockGmi.setGameData.mock.calls[0][1].stateKey).not.toStrictEqual(expect.any(Array));
+        });
     });
 
     describe("Returned get method", () => {


### PR DESCRIPTION
* Force states to always serialise to an Object (fp.set will serialise to an array if numeric keys are used)
