### PR TITLE
[CGPROD-2615] Remove exit stat being fired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 |---------|-------------|
 | 3.8.1 ||
 | | Fixed webfontloader loading from paths not relative to the theme directory. |
+| | Fixed exit stat firing twice. |
 | 3.8.0 ||
 | | Bump to Phaser 3.24.1. |
 | | Sets scroll factor to zero for all gel layout items so camera movements is ignored. |

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -30,7 +30,6 @@ export const config = screen => {
             channel: buttonsChannel(screen),
             action: () => {
                 gmi.exit();
-                gmi.sendStatsEvent("exit", "click");
             },
         },
         home: {

--- a/test/core/layout/gel-defaults.test.js
+++ b/test/core/layout/gel-defaults.test.js
@@ -97,10 +97,6 @@ describe("Layout - Gel Defaults", () => {
         test("exits the game using the GMI", () => {
             expect(mockGmi.exit).toHaveBeenCalled();
         });
-
-        test("sends a stat to the GMI", () => {
-            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("exit", "click");
-        });
     });
 
     describe("Home Button Callback", () => {


### PR DESCRIPTION
already done in CAGE on `gmi.exit()`