### PR TITLE
[CGPROD-2701] nudge devs towards achievement variety

### DIFF
--- a/docs/development/achievements.md
+++ b/docs/development/achievements.md
@@ -25,7 +25,7 @@ Achievement description objects look like this:
 * **description** [string] Description that will be displayed in the achievements list.
 * **points** [integer] Currently unused but required for future use. Should add up to 1000 points per game but otherwise can be weighted for difficulty or designer preference.
 
-## Optional Parameters
+**Optional Parameters:**
 * **maxProgress** [integer] Enables the progress bar and sets its limit.
 * **position** [string] This is the position that specifies where the achievements notification should show. Can be either "top" or "bottom" - defaults to "bottom".
 * **additional** {prefix [string], text [string]} Add a secondary text element to the description.

--- a/docs/development/achievements.md
+++ b/docs/development/achievements.md
@@ -21,7 +21,7 @@ Achievement description objects look like this:
 
 **Required Parameters:**
 * **key** [string a-z0-9_] a unique (per game) identifier, lowercase alphanumeric with underscore. The key is used for the asset, which will convert underscores to dashes when loading (e.g `this_key` will become `this-key.png`).
-* **name** [string] This is the human readable name that will be displayed in the achievements list. 
+* **name** [string] This is the human readable name that will be displayed in the achievements list.
 * **description** [string] Description that will be displayed in the achievements list.
 * **points** [integer] Currently unused but required for future use. Should add up to 1000 points per game but otherwise can be weighted for difficulty or designer preference.
 

--- a/docs/development/achievements.md
+++ b/docs/development/achievements.md
@@ -17,7 +17,7 @@ Achievement description objects look like this:
 }
 ```
 
-`name` and `description` should be changed from default values so that your achievements have text that fits the look and feel of your game. These objects also create the achievements list and should be ordered to reflect progression in your game.
+`name` and `description` should be changed from default values so that your achievements have text that fits the look and feel of your game. These objects should also be ordered sensibly to reflect progression in your game.
 
 **Required Parameters:**
 * **key** [string a-z0-9_] a unique (per game) identifier, lowercase alphanumeric with underscore. The key is used for the asset, which will convert underscores to dashes when loading (e.g `this_key` will become `this-key.png`).

--- a/docs/development/achievements.md
+++ b/docs/development/achievements.md
@@ -17,7 +17,7 @@ Achievement description objects look like this:
 }
 ```
 
-`name` and `description` should be changed from their default values so that your achievements have text that fits the look and feel of your game. These objects also create the achievements list and should be ordered to reflect progression in your game.
+`name` and `description` should be changed from default values so that your achievements have text that fits the look and feel of your game. These objects also create the achievements list and should be ordered to reflect progression in your game.
 
 **Required Parameters:**
 * **key** [string a-z0-9_] a unique (per game) identifier, lowercase alphanumeric with underscore. The key is used for the asset, which will convert underscores to dashes when loading (e.g `this_key` will become `this-key.png`).

--- a/docs/development/achievements.md
+++ b/docs/development/achievements.md
@@ -17,7 +17,7 @@ Achievement description objects look like this:
 }
 ```
 
-`name` and `description` should be changed from default values so that your achievements have text that fits the look and feel of your game. These objects should also be ordered sensibly to reflect progression in your game.
+`name` and `description` should be changed from their defaults to values that fit the look and feel of your game. These objects should also be ordered sensibly to reflect progression in your game.
 
 **Required Parameters:**
 * **key** [string a-z0-9_] a unique (per game) identifier, lowercase alphanumeric with underscore. The key is used for the asset, which will convert underscores to dashes when loading (e.g `this_key` will become `this-key.png`).

--- a/docs/development/achievements.md
+++ b/docs/development/achievements.md
@@ -1,22 +1,12 @@
 # Achievements System
 
-## How To Enable
-Achievements are enabled and configured per theme.
-To enable the achievements system add `"achievements": true` to the game block of the theme config `themes/#####/config/config.json5`. e.g:
+Achievements are enabled and configured in the theme.
 
-```json5
-{
-  "game": {
-      "music": "loadscreen.backgroundMusicTwo",
-      "achievements": true
-    }
- }       
-```
+The game will attempt to load achievements from `themes/#####/achievements/config.json5`.
 
-## Configuration
-Once the above flag is set to true the game will attempt to load an achievements config file from `themes/#####/achievements/config.json`.
+This `config.json5` should contain an array of achievement description objects. To disable achievements, make this array empty. 
 
-The config.json should be an array of achievement description objects:
+Achievement description objects look like this:
 
 ```json
 {
@@ -26,9 +16,12 @@ The config.json should be an array of achievement description objects:
     "points": 100
 }
 ```
+
+`name` and `description` should be changed from their default values so that your achievements have text that fits the look and feel of your game. These objects also create the achievements list and should be ordered to reflect progression in your game.
+
 **Required Parameters:**
 * **key** [string a-z0-9_] a unique (per game) identifier, lowercase alphanumeric with underscore. The key is used for the asset, which will convert underscores to dashes when loading (e.g `this_key` will become `this-key.png`).
-* **name** [string] This is the human readable name that will be displayed in the achievements list.
+* **name** [string] This is the human readable name that will be displayed in the achievements list. 
 * **description** [string] Description that will be displayed in the achievements list.
 * **points** [integer] Currently unused but required for future use. Should add up to 1000 points per game but otherwise can be weighted for difficulty or designer preference.
 

--- a/themes/default/achievements/config.json5
+++ b/themes/default/achievements/config.json5
@@ -1,9 +1,9 @@
 // To disable achievements, remove all the achievements in the array.
 [
     {
-        key: "just_started",
-        name: "Just Getting Star-ted",
-        description: "You collected your first star.",
+        key: "just_started", // i.e. do gmi.achievements.set({ key: "just_started" }) to mark this achievement complete
+        name: "CHANGE_THESE_STRINGS_Just Getting Star-ted", // update name strings to reflect your game's look and feel
+        description: "CHANGE_THESE_STRINGS_You collected your first star.", // update description strings to reflect your game's look and feel
         points: 100, // the total points for all achievements should equal 1000
     },
     {


### PR DESCRIPTION
- Updated `achievements.md` - remove redundant instruction on enabling achievements, clearer guidance on renaming / reordering achievements
- Updated `themes/default/achievements/config.json5` - explanatory comments, prefix strings CHANGE_THESE_STRINGS for clarity