### PR TITLE
[CGPROD-2708] fix silent audio on conditional assets debug screen

### DIFF
--- a/src/core/debug/launcher.js
+++ b/src/core/debug/launcher.js
@@ -65,6 +65,8 @@ export class Launcher extends Screen {
 
         this.setLayout(["home"]);
 
+        this.sound.pauseOnBlur = false;
+
         Object.keys(examples).map(getButtonConfig(this)).map(addButton);
     }
 }

--- a/test/core/debug/launcher.test.js
+++ b/test/core/debug/launcher.test.js
@@ -52,6 +52,9 @@ describe("Examples Launcher", () => {
             setPath: jest.fn(),
             pack: jest.fn(),
         };
+        launcher.sound = {
+            pauseOnBlur: true,
+        };
 
         examplesModule.examples = {
             example1: {
@@ -109,6 +112,10 @@ describe("Examples Launcher", () => {
             window.prompt = () => null;
             eventBus.subscribe.mock.calls[5][0].callback();
             expect(launcher._data.transient.example3).toStrictEqual({});
+        });
+
+        test("sets sound.pauseOnBlur to false", () => {
+            expect(launcher.sound.pauseOnBlur).toBe(false);
         });
     });
 });


### PR DESCRIPTION
- `window.prompt()` we added to parameterise the conditional assets screen steals focus in a browser-dependent way
- so, prevent the audio engine pausing on blur.