### PR TITLE
[CGPROD-2720] fix error spam on missing hover states for GEL buttons

### DIFF
--- a/src/core/layout/gel-button.js
+++ b/src/core/layout/gel-button.js
@@ -77,7 +77,11 @@ export class GelButton extends Phaser.GameObjects.Container {
     setupMouseEvents(config, screen) {
         this.on("pointerup", () => this.onPointerUp(config, screen));
         this.on("pointerout", () => this.sprite.setFrame(0));
-        this.on("pointerover", () => this.sprite.setFrame(1));
+        this.on("pointerover", () => {
+            if (this.sprite.texture.frames['1']) {
+                this.sprite.setFrame(1);
+            }
+        });
     }
 
     setHitArea(metrics) {

--- a/src/core/layout/gel-button.js
+++ b/src/core/layout/gel-button.js
@@ -77,11 +77,7 @@ export class GelButton extends Phaser.GameObjects.Container {
     setupMouseEvents(config, screen) {
         this.on("pointerup", () => this.onPointerUp(config, screen));
         this.on("pointerout", () => this.sprite.setFrame(0));
-        this.on("pointerover", () => {
-            if (this.sprite.texture.frames["1"]) {
-                this.sprite.setFrame(1);
-            }
-        });
+        this.on("pointerover", () => this.sprite.texture.frames["1"] && this.sprite.setFrame(1));
     }
 
     setHitArea(metrics) {

--- a/src/core/layout/gel-button.js
+++ b/src/core/layout/gel-button.js
@@ -78,7 +78,7 @@ export class GelButton extends Phaser.GameObjects.Container {
         this.on("pointerup", () => this.onPointerUp(config, screen));
         this.on("pointerout", () => this.sprite.setFrame(0));
         this.on("pointerover", () => {
-            if (this.sprite.texture.frames['1']) {
+            if (this.sprite.texture.frames["1"]) {
                 this.sprite.setFrame(1);
             }
         });

--- a/test/core/layout/gel-button.test.js
+++ b/test/core/layout/gel-button.test.js
@@ -47,6 +47,12 @@ describe("Gel Button", () => {
             play: jest.fn(),
             setDisplaySize: jest.fn(),
             setScrollFactor: jest.fn(),
+            texture: {
+                frames: {
+                    0: "foo",
+                    1: "bar",
+                },
+            },
         };
         mockScene = {
             add: {
@@ -163,6 +169,16 @@ describe("Gel Button", () => {
             });
             new GelButton(mockScene, mockX, mockY, mockConfig);
             expect(mockSprite.setFrame).toHaveBeenCalledWith(1);
+        });
+        test("pointerover event does not set frame to 1 if no frame 1 exists", () => {
+            mockSprite.texture.frames = { 0: "foo" };
+            GelButton.prototype.on = jest.fn((event, callback) => {
+                if (event === Phaser.Input.Events.POINTER_OVER) {
+                    callback();
+                }
+            });
+            new GelButton(mockScene, mockX, mockY, mockConfig);
+            expect(mockSprite.setFrame).not.toHaveBeenCalled();
         });
         test("callback is added to the POINTER_UP event emitter", () => {
             GelButton.prototype.on = jest.fn((event, callback) => {


### PR DESCRIPTION
- GEL buttons now check that frame 1 exists before trying to set their sprite to frame 1
- Added unit test