### PR TITLE
[CGPROD-2802] Fix crash on pressing enter key on how to play screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | Fixes bug when pressing the Enter or Space key on the how to play screen. |
 | | Rename item registry to 'catalogue'. Configs can now have a catalogueKey which prompts the loader to load a matching json5 from theme/default/items/. |
 | | Add item registry as preparation for the shop component. | 
 | | Set active tracked pointers to 4 to support virtual joysticks. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -12886,6 +12886,12 @@
             "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
             "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
         },
+        "node-forge": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
+            "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+            "dev": true
+        },
         "node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -14676,14 +14682,6 @@
             "dev": true,
             "requires": {
                 "node-forge": "0.9.0"
-            },
-            "dependencies": {
-                "node-forge": {
-                    "version": "0.10.0",
-                    "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-                    "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-                    "dev": true
-                }
             }
         },
         "semver": {

--- a/src/core/accessibility/accessible-dom-element.js
+++ b/src/core/accessibility/accessible-dom-element.js
@@ -11,7 +11,7 @@ const keyUp = options => event => {
     const spaceKey = event.key === " ";
 
     if (enterKey || spaceKey) {
-        options.onClick();
+        options.onClick && options.onClick();
     }
 };
 

--- a/test/core/accessibility/accessible-dom-element.test.js
+++ b/test/core/accessibility/accessible-dom-element.test.js
@@ -167,6 +167,12 @@ describe("Accessible DOM Element", () => {
             expect(options.onClick).toHaveBeenCalled();
         });
 
+        test("does not call onClick if options does not have an onClick method", () => {
+            delete options.onClick;
+            const mockElement = accessibleDomElement(options);
+            expect(() => mockElement.events.keyup({ key: "Enter" })).not.toThrow();
+        });
+
         test("does not call onClick when a key that isn't space or escape fires the event", () => {
             const mockElement = accessibleDomElement(options);
             const keyUpEvent = { key: "mockKey" };


### PR DESCRIPTION
The how to play screen has that "accessible carousel" thing that has a weird screen reader only div on it that reads out what page you are on. It doesn't have a click event on it so it crashes.