### PR TITLE
[CGPROD-2797] safe area debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | Add debug key to visualise safe interactable area
 | 3.8.6 ||
 | | Ensure all gel buttons have a valid event channel. |
 | | Adds collections. |

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -25,9 +25,5 @@ export class Home extends Screen {
             name: "play",
             callback: this.navigation.next,
         });
-
-        // console.log('BEEBUG: this.layout.getSafeArea()', this.layout.getSafeArea());
-        // const { width, height } = this.layout.getSafeArea();
-        // const safeRect = this.add.rectangle(0, 0, width, height, 0xff0000, 0.5);
     }
 }

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -25,5 +25,9 @@ export class Home extends Screen {
             name: "play",
             callback: this.navigation.next,
         });
+
+        // console.log('BEEBUG: this.layout.getSafeArea()', this.layout.getSafeArea());
+        // const { width, height } = this.layout.getSafeArea();
+        // const safeRect = this.add.rectangle(0, 0, width, height, 0xff0000, 0.5);
     }
 }

--- a/src/core/debug/debug.js
+++ b/src/core/debug/debug.js
@@ -5,6 +5,7 @@
  */
 import fp from "../../../lib/lodash/fp/fp.js";
 import * as debugLayout from "./layout-debug-draw.js";
+import * as safeAreaLayout from "./safe-area-draw.js";
 import { createMeasure } from "./measure/measure.js";
 
 const makeToggle = (val, fn, scene) => () =>
@@ -53,6 +54,7 @@ function create() {
 
     this.debug.draw.layout = debugLayout.create(this.debug.container);
     this.debug.draw.measure = createMeasure(this.debug.container);
+    this.debug.draw.safeArea = safeAreaLayout.create(this.debug.container);
 
     const fileLabel = {
         x: -400,
@@ -70,10 +72,11 @@ function create() {
     this.input.keyboard.addKey("r").on("up", toggleCSS);
     this.input.keyboard.addKey("t").on("up", this.debug.draw.measure);
     this.navigation.debug && this.input.keyboard.addKey("y").on("up", this.navigation.debug.bind(this));
+    this.input.keyboard.addKey("u").on("up", this.debug.draw.safeArea)
     window.__debug.screen = this;
 }
 
-const shutdown = scene => ["q", "w", "e", "r", "t", "y"].forEach(scene.input.keyboard.removeKey, scene.input.keyboard);
+const shutdown = scene => ["q", "w", "e", "r", "t", "y", "u"].forEach(scene.input.keyboard.removeKey, scene.input.keyboard);
 
 export const addEvents = scene => {
     scene.events.on("create", create, scene);

--- a/src/core/debug/debug.js
+++ b/src/core/debug/debug.js
@@ -72,11 +72,12 @@ function create() {
     this.input.keyboard.addKey("r").on("up", toggleCSS);
     this.input.keyboard.addKey("t").on("up", this.debug.draw.measure);
     this.navigation.debug && this.input.keyboard.addKey("y").on("up", this.navigation.debug.bind(this));
-    this.input.keyboard.addKey("u").on("up", this.debug.draw.safeArea)
+    this.input.keyboard.addKey("u").on("up", this.debug.draw.safeArea);
     window.__debug.screen = this;
 }
 
-const shutdown = scene => ["q", "w", "e", "r", "t", "y", "u"].forEach(scene.input.keyboard.removeKey, scene.input.keyboard);
+const shutdown = scene =>
+    ["q", "w", "e", "r", "t", "y", "u"].forEach(scene.input.keyboard.removeKey, scene.input.keyboard);
 
 export const addEvents = scene => {
     scene.events.on("create", create, scene);

--- a/src/core/debug/safe-area-draw.js
+++ b/src/core/debug/safe-area-draw.js
@@ -16,8 +16,10 @@ export const create = parent => {
     const safeAreaDebugElement = [...createSafeArea(parent)];
 
     const resize = () => {
-        const { width, height } = parent.scene.layout.getSafeArea();
+        const mirrorY = false;
+        const { top, width, height } = parent.scene.layout.getSafeArea({}, mirrorY);
         safeAreaDebugElement[0].setSize(width, height);
+        safeAreaDebugElement[0].setPosition(0, (height - Math.abs(top) * 2) / 2);
     };
 
     onScaleChange.add(resize);

--- a/src/core/debug/safe-area-draw.js
+++ b/src/core/debug/safe-area-draw.js
@@ -1,0 +1,39 @@
+/**
+ * @copyright BBC 2020
+ * @author BBC Children's D+E
+ * @license Apache-2.0
+ */
+import { onScaleChange } from "../scaler.js";
+import { eventBus } from "../event-bus.js";
+
+const createSafeArea = parent => {
+    const safeArea = [parent.scene.add.tileSprite(0,0,0,0, "gelDebug.FF0030-hatch")];
+    safeArea.map(area => parent.add(area));
+    return safeArea;
+}
+
+export const create = parent => {
+    const safeAreaDebugElement = [...createSafeArea(parent)];
+
+    const resize = () => {
+        const { width, height } = parent.scene.layout.getSafeArea();
+        safeAreaDebugElement[0].setSize(width, height);
+    };
+
+    onScaleChange.add(resize);
+    resize();
+
+    const shutdown = () => eventBus.removeSubscription({ channel: "scaler", name: "sizeChange", callback: resize });
+
+    parent.scene.events.once("shutdown", shutdown);
+
+    const toggle = () => {
+        const visible = !safeAreaDebugElement[0].visible;
+        safeAreaDebugElement.forEach(el => (el.visible = visible));
+        return visible;
+    };
+
+    toggle();
+
+    return toggle;
+};

--- a/src/core/debug/safe-area-draw.js
+++ b/src/core/debug/safe-area-draw.js
@@ -7,10 +7,10 @@ import { onScaleChange } from "../scaler.js";
 import { eventBus } from "../event-bus.js";
 
 const createSafeArea = parent => {
-    const safeArea = [parent.scene.add.tileSprite(0,0,0,0, "gelDebug.FF0030-hatch")];
+    const safeArea = [parent.scene.add.tileSprite(0, 0, 0, 0, "gelDebug.FF0030-hatch")];
     safeArea.map(area => parent.add(area));
     return safeArea;
-}
+};
 
 export const create = parent => {
     const safeAreaDebugElement = [...createSafeArea(parent)];

--- a/src/core/layout/safe-area.js
+++ b/src/core/layout/safe-area.js
@@ -16,7 +16,7 @@ const defaultSafeAreaGroups = {
     right: [{ id: "middleRightSafe" }, { id: "topRight", fixedWidth: 64 }],
 };
 
-export const getSafeAreaFn = groups => (groupOverrides = {}) => {
+export const getSafeAreaFn = groups => (groupOverrides = {}, mirrorY = true) => {
     const metrics = getMetrics();
     const safe = { ...defaultSafeAreaGroups, ...groupOverrides };
     const pad = metrics.isMobile ? { x: 0, y: 0 } : fp.mapValues(metrics.screenToCanvas, { x: 20, y: 10 });
@@ -30,7 +30,6 @@ export const getSafeAreaFn = groups => (groupOverrides = {}) => {
         ? groups[safe.top].y + groups[safe.top].height
         : metrics.verticalBorderPad - metrics.stageHeight / 2;
     const width = Math.min(...safe.right.map(getLeftSide)) - pad.x - left;
-    const height = Math.min(groups[safe.bottom].y - pad.y, -top) - top;
-
+    const height = mirrorY ? Math.min(groups[safe.bottom].y - pad.y, -top) - top : groups[safe.bottom].y - pad.y - top;
     return new Phaser.Geom.Rectangle(left, top, width, height);
 };

--- a/src/main.js
+++ b/src/main.js
@@ -57,7 +57,7 @@ const screens = {
             debug: "debug",
             //Example of custom routing function
             next: scene => {
-                scene.navigate("shop");
+                scene.navigate("narrative");
             },
         },
     },

--- a/test/core/debug/debug.test.js
+++ b/test/core/debug/debug.test.js
@@ -70,6 +70,7 @@ describe("Debug system", () => {
                         addKeys: jest.fn(() => ({ c: { on: jest.fn() } })),
                     },
                 },
+                layout: { getSafeArea: jest.fn().mockReturnValue({ top: 1, width: 2, height: 3 }) },
             },
             setDepth: jest.fn(),
             add: jest.fn(),

--- a/test/core/debug/debug.test.js
+++ b/test/core/debug/debug.test.js
@@ -317,6 +317,11 @@ describe("Debug system", () => {
                 expect.any(Number),
                 expect.any(Array),
             );
+            expect(mockScreen.input.keyboard.removeKey).toHaveBeenCalledWith(
+                "u",
+                expect.any(Number),
+                expect.any(Array),
+            );
         });
     });
 

--- a/test/core/debug/safe-area-draw.test.js
+++ b/test/core/debug/safe-area-draw.test.js
@@ -1,7 +1,61 @@
+/**
+ * @copyright BBC 2020
+ * @author BBC Children's D+E
+ * @license Apache-2.0
+ */
 import * as safeAreaDraw from "../../../src/core/debug/safe-area-draw.js";
+import { eventBus } from "../../../src/core/event-bus.js";
 
 describe("safe area draw", () => {
-    test("fails", () => {
-        expect(false).toBe(true);
+    let mockScreen;
+    let mockTileSprite;
+    let mockContainer;
+
+    beforeEach(() => {
+        mockTileSprite = {
+            setPosition: jest.fn(),
+            setSize: jest.fn(),
+        };
+
+        mockScreen = {
+            add: {
+                tileSprite: jest.fn().mockReturnValue(mockTileSprite),
+            },
+            layout: {
+                getSafeArea: jest.fn().mockReturnValue({ top: 1, width: 2, height: 3 }),
+            },
+            events: {
+                once: jest.fn(),
+            },
+        };
+
+        mockContainer = {
+            scene: mockScreen,
+            add: jest.fn(),
+        };
+
+        eventBus.removeSubscription = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    describe("create function", () => {
+        test("adds a tileSprite to represent the safe interactable area", () => {
+            safeAreaDraw.create(mockContainer);
+            expect(mockTileSprite.setSize.mock.calls[0]).toEqual([2, 3]);
+        });
+
+        test("removes scale subscription on scene shutdown", () => {
+            safeAreaDraw.create(mockContainer);
+            expect(mockScreen.events.once).toHaveBeenLastCalledWith("shutdown", expect.any(Function));
+            mockScreen.events.once.mock.calls[0][1]();
+            const removeSubCall = eventBus.removeSubscription.mock.calls[0][0];
+            expect(removeSubCall.channel).toBe("scaler");
+            expect(removeSubCall.name).toBe("sizeChange");
+            expect(removeSubCall.callback).toStrictEqual(expect.any(Function));
+        });
     });
 });

--- a/test/core/debug/safe-area-draw.test.js
+++ b/test/core/debug/safe-area-draw.test.js
@@ -1,0 +1,7 @@
+import * as safeAreaDraw from "../../../src/core/debug/safe-area-draw.js";
+
+describe("safe area draw", () => {
+    test("fails", () => {
+        expect(false).toBe(true);
+    });
+});

--- a/test/core/layout/safe-area.test.js
+++ b/test/core/layout/safe-area.test.js
@@ -64,6 +64,13 @@ describe("getSafeArea", () => {
         expect(safeAreaFn({ top: false })).toEqual(new Phaser.Geom.Rectangle(-130, -384, 360, 768));
     });
 
+    test("does not conform the bottom pad value if mirrorY is passed as false", () => {
+        mockMetrics.isMobile = false;
+        mockGroups.bottomCenter.y = 1000;
+        const safeAreaFn = getSafeAreaFn(mockGroups);
+        expect(safeAreaFn({}, false)).toEqual(new Phaser.Geom.Rectangle(-130, -100, 360, 1090));
+    });
+
     test("topLeft and topRight values have a fixed width of 64 ", () => {
         mockGroups.topLeft.width = 0;
         mockGroups.topRight.width = 0;

--- a/themes/default/home/config.json5
+++ b/themes/default/home/config.json5
@@ -13,7 +13,7 @@
         {
             x: -390,
             y: -40,
-            text: "DEBUG DRAW OPTIONS:\nQ: Toggle GEL safe Area\nW: Toggle Groups\nE: Toggle Buttons\nR: Toggle CSS debug\nT: Toggle Measuring Tool\nY: Examples Launcher",
+            text: "DEBUG DRAW OPTIONS:\nQ: Toggle GEL safe Area\nW: Toggle Groups\nE: Toggle Buttons\nR: Toggle CSS debug\nT: Toggle Measuring Tool\nY: Examples Launcher\nU: View Safe Area",
         },
     ],
 }


### PR DESCRIPTION
- Provides a new key ('U') in debug mode that shows the safe area
- Adds `safe-area-draw.js` to get and draw this safe area
- Adds a new param `mirrorY` to `scene.layout.getSafeArea()`, defaulting to true, which has the safe area vertically centred (the way we want it in Select) 
- Uses mirrorY = false when getting the safe area for debug mode
