### PR TITLE
CGPROD 2850 4/3 Area buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 | Version | Description |
 |---------|-------------|
+| | Buttons within the 4/3 area now sit exactly on the edge in mobile breakpoint. |
+| | Buttons will move inwards if the screen width causes the border pad to overlap the 4/3 area. |
 | | Add accessibility for scrollable list component. |
 | | Remove states system in favour of collections. |
 | | Add debug key to visualise safe interactable area. | 

--- a/test/core/layout/gel-group.test.js
+++ b/test/core/layout/gel-group.test.js
@@ -191,6 +191,56 @@ describe("Group", () => {
                 expect(group.x).toBe(0);
                 expect(group.y).toBe(-50);
             });
+
+            test("Aligns to the edges of the 4/3 area in mobile mode", () => {
+                const testMetrics = {
+                    isMobile: true,
+                    horizontalBorderPad: 10,
+                    stageWidth: 1400,
+                    scale: 1,
+                    safeHorizontals: {
+                        left: -400,
+                        right: 400,
+                    },
+                    verticals: {},
+                };
+
+                const leftGroup = new GelGroup(mockScene, parentGroup, "middle", "left", testMetrics, true, false);
+                leftGroup.addButton(config);
+                leftGroup.reset(testMetrics);
+
+                const rightGroup = new GelGroup(mockScene, parentGroup, "middle", "right", testMetrics, true, false);
+                rightGroup.addButton(config);
+                rightGroup.reset(testMetrics);
+
+                expect(leftGroup.x).toBe(-400);
+                expect(rightGroup.x).toBe(400);
+            });
+
+            test("Aligns to the border pad if screen width overlaps the 4/3 area in mobile mode", () => {
+                const testMetrics = {
+                    isMobile: true,
+                    horizontalBorderPad: 10,
+                    stageWidth: 790,
+                    scale: 1,
+                    safeHorizontals: {
+                        left: -400,
+                        right: 400,
+                    },
+                    verticals: {},
+                };
+
+                const leftGroup = new GelGroup(mockScene, parentGroup, "middle", "left", testMetrics, true, false);
+                leftGroup.addButton(config);
+                leftGroup.reset(testMetrics);
+
+                const rightGroup = new GelGroup(mockScene, parentGroup, "middle", "right", testMetrics, true, false);
+                rightGroup.addButton(config);
+                rightGroup.reset(testMetrics);
+
+                expect(leftGroup.x).toBe(-385);
+                expect(rightGroup.x).toBe(385);
+            });
         });
 
         describe("when vPos is top and hPos is right", () => {
@@ -257,6 +307,8 @@ describe("Group", () => {
                         hitArea: {
                             left: 0,
                             top: 0,
+                            width: 50,
+                            height: 50,
                         },
                     },
                     config: {
@@ -267,8 +319,9 @@ describe("Group", () => {
                     updateTransform: () => {},
                     resize: buttonResizeStub,
                     getHitAreaBounds: mockGetHitAreaBounds,
-                    sprite: { width: 200, height: 100 },
+                    sprite: { width: 100, height: 100 },
                 }));
+
                 group.addButton(config);
 
                 createButtonStub.mockImplementation(() => ({
@@ -280,6 +333,8 @@ describe("Group", () => {
                         hitArea: {
                             left: -1000,
                             top: -1000,
+                            width: 50,
+                            height: 50,
                         },
                     },
                     config: {
@@ -290,8 +345,9 @@ describe("Group", () => {
                     updateTransform: () => {},
                     resize: buttonResizeStub,
                     getHitAreaBounds: mockGetHitAreaBounds,
-                    sprite: { width: 200, height: 100 },
+                    sprite: { width: 100, height: 100 },
                 }));
+
                 group.addButton(config);
                 group.reset(metrics);
 


### PR DESCRIPTION
* Buttons within the 4/3 area now sit exactly on the edge in mobile breakpoint.
* Buttons will move inwards if the screen width causes the border pad to overlap the 4/3 area.

Mobile mode wide:
![image](https://user-images.githubusercontent.com/961406/96837538-8497c980-143e-11eb-8448-49abfaea5bb9.png)

Mobile mode 4/3:

![image](https://user-images.githubusercontent.com/961406/96837617-a1340180-143e-11eb-923c-3de0065a9e33.png)

Old mobile mode:
![image](https://user-images.githubusercontent.com/961406/96837693-bdd03980-143e-11eb-9394-4447166bae4c.png)

