### PR TITLE
[CGPROD-2674] fix resize being a couple of px off

### DIFF
--- a/src/core/layout/scrollable-list/scrollable-list.js
+++ b/src/core/layout/scrollable-list/scrollable-list.js
@@ -70,7 +70,7 @@ const createItem = (scene, item) =>
 const resizePanel = (scene, panel) => {
     const t = panel.t;
     const items = panel.getByName("grid", true).getElement("items");
-    items.forEach(label => scaleButton(label.children[0], scene.layout, panel.space.top));
+    items.forEach(label => scaleButton(label.children[0], scene.layout, panel.space.left));
     const safeArea = getPanelY(scene);
     panel.minHeight = safeArea.height;
     panel.y = safeArea.y;


### PR DESCRIPTION
- in post-flight on CGPROD-2674 it was noted that the scrollable list was not conforming to the edges of the safe area
- in a previous UX chat we noted X- and Y-axis padding values should be different to conform to the UX spec
- following the change we were not conforming because we were using a Y where we should have used an X.
- fixed.