### PR TITLE
[CGPROD-2858] shop debug screen - unbreak asset paths, the fast way

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -107,7 +107,7 @@ const screens = {
         scene: Shop,
         routes: {
             home: "home",
-        }
+        },
     },
     // Overlays
     "how-to-play": {

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import { Narrative } from "./components/narrative.js";
 import { Results } from "./components/results/results-screen.js";
 import { Select } from "./components/select/select-screen.js";
 import { HowToPlay } from "./components/how-to-play.js";
+import { Shop } from "./components/shop/shop.js";
 import { Game } from "./components/game.js";
 import { Pause } from "./components/overlays/pause.js";
 import { settingsChannel } from "./core/settings.js";
@@ -101,6 +102,12 @@ const screens = {
             restart: "game",
             home: "home",
         },
+    },
+    shop: {
+        scene: Shop,
+        routes: {
+            home: "home",
+        }
     },
     // Overlays
     "how-to-play": {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -34,6 +34,7 @@ describe("Main", () => {
             "level-select",
             "game",
             "results",
+            "shop",
             "how-to-play",
             "pause",
         ];


### PR DESCRIPTION
- Previous PR on this ticket broke all the asset paths as they relied on the shop existing in the theme and main.js
- Ideally we'd have all debug assets under the debug assets folder. however:
- gel buttons depend on a dot-separated asset path
- debug mode depends on underscore-separated paths
- hilarity ensues
- as a quick fix, add Shop back to main.js