### PR TITLE
[CGPROD-2894] If gmi.achievements does not exist, don't error.

### DIFF
--- a/src/components/home.js
+++ b/src/components/home.js
@@ -14,7 +14,8 @@ import { gmi } from "../core/gmi/gmi.js";
 
 export class Home extends Screen {
     create() {
-        const achievements = gmi.achievements.get().length ? ["achievements"] : [];
+        const achievements =
+            gmi.achievements && gmi.achievements.get && gmi.achievements.get().length ? ["achievements"] : [];
         const debug = isDebug() ? ["debug"] : [];
         this.addBackgroundItems();
         const buttons = ["exit", "howToPlay", "play", "audio", "settings"];

--- a/src/components/overlays/pause.js
+++ b/src/components/overlays/pause.js
@@ -19,7 +19,8 @@ export class Pause extends Screen {
         this.addBackgroundItems();
         const parentKey = this._data.addedBy.scene.key;
         const isAboveSelectScreen = parentKey.includes("select");
-        const achievements = gmi.achievements.get().length ? ["achievements"] : [];
+        const achievements =
+            gmi.achievements && gmi.achievements.get && gmi.achievements.get().length ? ["achievements"] : [];
         const pauseReplay = this.context.navigation[parentKey].routes.restart ? ["pauseReplay"] : [];
         let levelSelect = this.context.navigation[this.scene.key].routes.select ? ["levelSelect"] : [];
         levelSelect = isAboveSelectScreen ? [] : levelSelect;

--- a/src/components/results/results-screen.js
+++ b/src/components/results/results-screen.js
@@ -36,7 +36,8 @@ export class Results extends Screen {
     }
 
     createLayout() {
-        const achievements = gmi.achievements.get().length ? ["achievementsSmall"] : [];
+        const achievements =
+            gmi.achievements && gmi.achievements.get && gmi.achievements.get().length ? ["achievementsSmall"] : [];
         const buttons = ["pause", "continueGame"];
         const onwardButton = fp.get(`${this.scene.key}.gameComplete`, this.transientData) ? "playAgain" : "restart";
         this.setLayout([...buttons, ...achievements, onwardButton]);

--- a/src/core/loader/loader.js
+++ b/src/core/loader/loader.js
@@ -94,7 +94,7 @@ export class Loader extends Screen {
         const config = getConfig(this, this.screenKeys);
         this.setConfig(config);
         GameSound.setButtonClickSound(this.scene.scene, "loader.buttonClick");
-        gmi.achievements.init(this.cache.json.get("achievements-data"));
+        gmi.achievements && gmi.achievements.init && gmi.achievements.init(this.cache.json.get("achievements-data"));
         loadCollections(this, config).then(loaderComplete(this));
     }
 }


### PR DESCRIPTION
https://jira.dev.bbc.co.uk/browse/CGPROD-2894

Stops genie erroring if `gmi.achievements` is not implemented on the gmi...