### PR TITLE
[CGPROD-2900] Remove extra navigate callback

### DIFF
--- a/src/components/game.js
+++ b/src/components/game.js
@@ -89,11 +89,7 @@ export class Game extends Screen {
             .on("pointerup", () => onLevelComplete());
         continueButton.config = { id: 4, ariaLabel: "Continue" };
         accessibilify(continueButton);
-        this.add
-            .text(300, 20, "Continue", buttonTextStyle)
-            .setOrigin(0.5)
-            .setInteractive({ useHandCursor: true })
-            .on("pointerup", () => onLevelComplete());
+        this.add.text(300, 20, "Continue", buttonTextStyle).setOrigin(0.5);
 
         const onLevelComplete = () => {
             const { id, title } = this.transientData["level-select"].choice;

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -468,11 +468,6 @@ describe("Game", () => {
                 expect(game.transientData.results).toEqual({ gems: 0, keys: 0, stars: 0, levelId: "Hard level" });
             });
 
-            test("saves data from the game when the continue text is clicked", () => {
-                continueTextClickedOn.mock.calls[0][1]();
-                expect(game.transientData.results).toEqual({ gems: 0, keys: 0, stars: 0, levelId: "Hard level" });
-            });
-
             test("saves levelId from the game when the continue button is clicked", () => {
                 continueButtonClickedOn.mock.calls[0][1]();
                 expect(game.transientData.results.levelId).toEqual("Hard level");
@@ -480,11 +475,6 @@ describe("Game", () => {
 
             test("navigates to the next screen when the continue button image is clicked", () => {
                 continueButtonClickedOn.mock.calls[0][1]();
-                expect(game.navigation.next).toHaveBeenCalled();
-            });
-
-            test("navigates to the next screen when the continue text is clicked", () => {
-                continueTextClickedOn.mock.calls[0][1]();
                 expect(game.navigation.next).toHaveBeenCalled();
             });
 


### PR DESCRIPTION
some reason there's a callback on both the continue text and the image and they were both firing navigate to the results screen events at the same time.