### PR TITLE
[CGPROD-2769] equip confirm screen

### DIFF
--- a/src/components/shop/transact.js
+++ b/src/components/shop/transact.js
@@ -7,15 +7,19 @@
 
 import { collections } from "../../core/collections.js";
 
-export const doTransaction = scene => transaction => {
+export const doTransaction = scene => tx => {
     const { shop, manage } = scene.config.paneCollections;
-    const shopCol = collections.get(shop);
     const invCol = collections.get(manage);
-    return buy(transaction, shopCol, invCol);
+    return (tx.title === "shop" && buy(tx, shop, invCol)) || (tx.title === "manage" && equip(tx, invCol));
 };
 
-const buy = (tx, shopCol, invCol) => {
+const buy = (tx, shop, invCol) => {
+    const shopCol = collections.get(shop);
     shopCol.set({ ...tx.item, state: "owned", qty: -1 });
     invCol.set({ ...tx.item, qty: +1 });
     return tx.item.price;
+};
+
+const equip = (tx, invCol) => {
+    invCol.set({ ...tx.item, state: "equipped" });
 };

--- a/test/components/shop/transact.test.js
+++ b/test/components/shop/transact.test.js
@@ -14,7 +14,7 @@ describe("doTransaction", () => {
     let doTransaction;
 
     const mockScene = {
-        config: { paneCollections: { shop: "foo", manage: "bar" } },
+        config: { paneCollections: { shop: "shop", manage: "manage" } },
     };
     const mockShopCol = { set: jest.fn(), get: jest.fn().mockReturnValue("baz") };
     const mockInvCol = { set: jest.fn() };
@@ -22,7 +22,7 @@ describe("doTransaction", () => {
 
     beforeEach(() => {
         doTransaction = transact.doTransaction(mockScene);
-        collections.get = jest.fn().mockReturnValueOnce(mockShopCol).mockReturnValue(mockInvCol);
+        collections.get = jest.fn().mockImplementation(type => (type === "shop" && mockShopCol) || mockInvCol);
     });
     afterEach(() => jest.clearAllMocks());
 
@@ -32,8 +32,8 @@ describe("doTransaction", () => {
             result = doTransaction(mockTx);
         });
         test("gets both collections", () => {
-            expect(collections.get).toHaveBeenCalledWith("foo");
-            expect(collections.get).toHaveBeenCalledWith("bar");
+            expect(collections.get).toHaveBeenCalledWith("shop");
+            expect(collections.get).toHaveBeenCalledWith("manage");
         });
         test("processes a buy transaction", () => {
             const expectedShopSet = { ...mockItem, state: "owned", qty: -1 };
@@ -43,6 +43,20 @@ describe("doTransaction", () => {
         });
         test("returns the price that was charged", () => {
             expect(result).toBe(50);
+        });
+    });
+    describe("when called from manage", () => {
+        beforeEach(() => {
+            mockTx = { title: "manage", item: mockItem };
+            result = doTransaction(mockTx);
+        });
+        test("only gets the inv collection", () => {
+            expect(collections.get).toHaveBeenCalledWith("manage");
+            expect(collections.get).not.toHaveBeenCalledWith("shop");
+        });
+        test("sets an 'equipped' state on the item", () => {
+            const expectedInvSet = { ...mockItem, state: "equipped" };
+            expect(mockInvCol.set.mock.calls[0][0]).toStrictEqual(expectedInvSet);
         });
     });
 });


### PR DESCRIPTION
- Mostly, just reuses existing functions created for the shop confirm screen
- Adds an equip transaction
- Does not visually update anything (this will be done in CGPROD-2928) but we can verify: dev tools => application => local storage => check state of local storage before & after the transaction.
