### PR TITLE
[CGPROD-2913] fix resize of scrollable list

### DIFF
--- a/src/components/shop/shop.js
+++ b/src/components/shop/shop.js
@@ -108,9 +108,6 @@ export class Shop extends Screen {
         const safeArea = getSafeArea(this.layout);
         this.panes.top.resize(safeArea);
         this.panes.confirm.resize(safeArea);
-        // this.panes.shop.resize();
-        // this.panes.manage.resize();
-
         this.title.setScale(getScaleFactor({ metrics, container: this.title, fixedWidth: true, safeArea }));
         this.title.setPosition(0, getYPos(metrics, safeArea));
         this.balance.setScale(getScaleFactor({ metrics, container: this.balance, safeArea }));

--- a/src/components/shop/shop.js
+++ b/src/components/shop/shop.js
@@ -107,6 +107,10 @@ export class Shop extends Screen {
         const metrics = getMetrics();
         const safeArea = getSafeArea(this.layout);
         this.panes.top.resize(safeArea);
+        this.panes.confirm.resize(safeArea);
+        // this.panes.shop.resize();
+        // this.panes.manage.resize();
+
         this.title.setScale(getScaleFactor({ metrics, container: this.title, fixedWidth: true, safeArea }));
         this.title.setPosition(0, getYPos(metrics, safeArea));
         this.balance.setScale(getScaleFactor({ metrics, container: this.balance, safeArea }));

--- a/src/core/layout/scrollable-list/scrollable-list.js
+++ b/src/core/layout/scrollable-list/scrollable-list.js
@@ -8,6 +8,7 @@ import { updatePanelOnFocus, updatePanelOnScroll } from "./scrollable-list-handl
 import { createGelButton, scaleButton } from "./scrollable-list-buttons.js";
 import * as a11y from "../../accessibility/accessibility-layer.js";
 import { collections } from "../../collections.js";
+import { onScaleChange } from "../../scaler.js";
 import fp from "../../../../lib/lodash/fp/fp.js";
 
 const createPanel = (scene, title, prepTx) => {
@@ -80,6 +81,9 @@ const resizePanel = (scene, panel) => {
 };
 
 const setupEvents = (scene, panel) => {
+    const scaleEvent = onScaleChange.add(() => resizePanel(scene, panel));
+    scene.events.once("shutdown", scaleEvent.unsubscribe);
+
     scene.scale.on(
         "resize",
         fp.debounce(10, () => resizePanel(scene, panel)),

--- a/test/core/layout/scrollable-list/scrollable-list.test.js
+++ b/test/core/layout/scrollable-list/scrollable-list.test.js
@@ -47,6 +47,7 @@ const mockScene = {
             label: jest.fn().mockReturnValue(mockLabel),
         },
     },
+    events: { once: jest.fn() },
     input: { topOnly: true },
     add: { image: jest.fn() },
     config: {
@@ -84,6 +85,7 @@ const mockGelButton = {
 };
 buttons.createGelButton = jest.fn().mockReturnValue(mockGelButton);
 buttons.scaleButton = jest.fn();
+scaler.onScaleChange.add = jest.fn().mockReturnValue({ unsubscribe: "foo" });
 const title = "shop";
 const initState = "cta";
 const mockPrepTransaction = jest.fn();
@@ -157,6 +159,11 @@ describe("Scrollable List", () => {
                     expect(mockSizer.add).toHaveBeenCalledWith(mockGridSizer, 1, "center", 0, true);
                 });
             });
+        });
+        test("adds a resize fn to the scaler's onScaleChange", () => {
+            const callback = scaler.onScaleChange.add.mock.calls[0][0];
+            callback();
+            expect(mockScrollablePanel.layout).toHaveBeenCalled();
         });
         test("assigns a callback to scene on resize", () => {
             expect(mockScene.scale.on.mock.calls[0][0]).toBe("resize");


### PR DESCRIPTION
- We had some situations where resizing the scrolly list would break the layout
- turns out that as well as a resize subscription, we also needed to add to onScaleChange