### PR TITLE
[CGPROD-2911] fix crashy click handlers

### DIFF
--- a/src/components/shop/menu-buttons.js
+++ b/src/components/shop/menu-buttons.js
@@ -32,11 +32,12 @@ export const createConfirmButtons = (scene, bounds, config, yOffset, callbackFn)
 const makeButton = (scene, config, buttonConfig, bounds, idx, offset, callback) => {
     const { x, y } = getButtonPosition(bounds, idx, offset);
     const gelButton = scene.add.gelButton(x + CAMERA_X, y + CAMERA_Y, buttonConfig);
-    eventBus.subscribe({
+    const event = eventBus.subscribe({
         callback,
         channel: buttonConfig.channel,
         name: buttonConfig.id,
     });
+    scene.events.once("shutdown", event.unsubscribe);
     setButtonOverlays(scene, gelButton, buttonConfig.title, config);
     accessibilify(gelButton);
     gelButton.setScale(getScale(bounds, gelButton));

--- a/src/core/layout/scrollable-list/scrollable-list-buttons.js
+++ b/src/core/layout/scrollable-list/scrollable-list-buttons.js
@@ -45,11 +45,12 @@ const createGelButton = (scene, item, title, state, prepTx) => {
 
     const callback = () => prepTx(item, title);
 
-    eventBus.subscribe({
+    const clickEvent = eventBus.subscribe({
         callback: handleClickIfVisible(gelButton, scene, callback),
         channel: gelConfig.channel,
         name: id,
     });
+    scene.events.once("shutdown", clickEvent.unsubscribe);
 
     scaleButton(gelButton, scene.layout, config.listPadding.x);
     makeAccessible(gelButton);

--- a/test/components/shop/menu-buttons.test.js
+++ b/test/components/shop/menu-buttons.test.js
@@ -33,6 +33,7 @@ describe("shop menu buttons", () => {
         scene: { key: "mockSceneKey" },
         setVisiblePane: jest.fn(),
         stack: jest.fn(),
+        events: { once: jest.fn() },
     };
     const mockConfig = {
         assetKeys: { buttonIcon: "mockIconKey", buttonBackground: "mockBackgroundKey" },
@@ -40,7 +41,8 @@ describe("shop menu buttons", () => {
     const mockOuterBounds = { y: 50, height: 400 };
     const mockInnerBounds = { x: 200, y: 50, height: 300, width: 100 };
     const yOffset = 47;
-    eventBus.subscribe = jest.fn();
+    const mockEvent = { unsubscribe: "foo" };
+    eventBus.subscribe = jest.fn().mockReturnValue(mockEvent);
     a11y.accessibilify = jest.fn();
 
     afterEach(() => jest.clearAllMocks());
@@ -80,6 +82,7 @@ describe("shop menu buttons", () => {
             expect(message.name).toBe("shop_menu_button");
             message.callback();
             expect(mockScene.stack).toHaveBeenCalledWith("shop");
+            expect(mockScene.events.once).toHaveBeenCalledWith("shutdown", "foo");
         });
         test("sets overlays for text and button icon", () => {
             expect(mockButton.overlays.set).toHaveBeenCalledTimes(4);

--- a/test/core/layout/scrollable-list/scrollable-list-buttons.test.js
+++ b/test/core/layout/scrollable-list/scrollable-list-buttons.test.js
@@ -46,6 +46,7 @@ describe("Scrollable List Buttons", () => {
         input: { y: 50 },
         scale: { displaySize: { height: 100 } },
         scene: { key: "shop" },
+        events: { once: jest.fn() },
     };
 
     const mockItem = {
@@ -55,7 +56,8 @@ describe("Scrollable List Buttons", () => {
 
     overlays.overlays1Wide = jest.fn();
     a11y.accessibilify = jest.fn();
-    eventBus.subscribe = jest.fn();
+    const mockEvent = { unsubscribe: "foo" };
+    eventBus.subscribe = jest.fn().mockReturnValue(mockEvent);
     handlers.handleClickIfVisible = jest.fn();
     const mockCallback = jest.fn();
 
@@ -90,6 +92,7 @@ describe("Scrollable List Buttons", () => {
             const callback = handlers.handleClickIfVisible.mock.calls[0][2];
             callback();
             expect(mockCallback).toHaveBeenCalled();
+            expect(mockScene.events.once).toHaveBeenCalledWith("shutdown", "foo");
         });
 
         test("scales the button", () => {


### PR DESCRIPTION
- Various buttons in the shop were lacking an unsubscribe on shutdown
- This meant that after the first launch of the shop in a given session, the event bus had two callbacks for each click, one of which would have a null pointer and therefore cause a crash.
- Added unsubscribe on shutdown via `scene.events.once`