### PR TITLE
[CGPROD-2844] use currency from inventory

### DIFF
--- a/debug/examples/shop.json5
+++ b/debug/examples/shop.json5
@@ -41,7 +41,7 @@
         },
         value: {
             type: "text",
-            key: "coin", // the item in the inventory collection used for currency
+            key: "coin", // the id of the currency item, which must exist in the inventory collection
             styles: {},
         },
     },

--- a/debug/examples/shop.json5
+++ b/debug/examples/shop.json5
@@ -55,6 +55,7 @@
         shop: "armoury",
         manage: "inventory",
     },
+    currencyItemKey: "coin",
     confirm: {
         detailView: true, // true === smaller image and more text. false === large image only.
         prompts: {

--- a/debug/examples/shop.json5
+++ b/debug/examples/shop.json5
@@ -41,7 +41,7 @@
         },
         value: {
             type: "text",
-            value: 100, // PH
+            key: "coin", // the item in the inventory collection used for currency
             styles: {},
         },
     },
@@ -55,7 +55,6 @@
         shop: "armoury",
         manage: "inventory",
     },
-    currencyItemKey: "coin",
     confirm: {
         detailView: true, // true === smaller image and more text. false === large image only.
         prompts: {

--- a/src/components/shop/balance-ui.js
+++ b/src/components/shop/balance-ui.js
@@ -8,6 +8,7 @@
 
 import { getXPos, getYPos, getScaleFactor, getSafeArea } from "./shop-layout.js";
 import { getMetrics } from "../../core/scaler.js";
+import { collections } from "../../core/collections.js";
 
 const styleDefaults = {
     fontFamily: "ReithSans",
@@ -17,13 +18,19 @@ const styleDefaults = {
 
 const makeElement = makerFns => conf => makerFns[conf.type](conf).setOrigin(0.5);
 
+const getBalanceValue = scene => {
+    const inventory = collections.get(scene.config.paneCollections.manage).getAll();
+    const currency = inventory.find(item => item.id === scene.config.balance.value.key);
+    return currency.qty;
+};
+
 export const createBalance = scene => {
     const safeArea = getSafeArea(scene.layout);
     const metrics = getMetrics();
     const image = conf => scene.add.image(0, 0, `${scene.assetPrefix}.${conf.key}`);
     const text = conf => {
         const textStyle = { ...styleDefaults, ...conf.styles };
-        return scene.add.text(0, 0, conf.value, textStyle);
+        return scene.add.text(0, 0, getBalanceValue(scene), textStyle);
     };
     const container = scene.add.container();
     const configs = scene.config.balance;

--- a/src/components/shop/balance-ui.js
+++ b/src/components/shop/balance-ui.js
@@ -18,11 +18,8 @@ const styleDefaults = {
 
 const makeElement = makerFns => conf => makerFns[conf.type](conf).setOrigin(0.5);
 
-const getBalanceValue = scene => {
-    const inventory = collections.get(scene.config.paneCollections.manage).getAll();
-    const currency = inventory.find(item => item.id === scene.config.balance.value.key);
-    return currency.qty;
-};
+const getBalanceValue = scene =>
+    collections.get(scene.config.paneCollections.manage).get(scene.config.balance.value.key).qty;
 
 export const createBalance = scene => {
     const safeArea = getSafeArea(scene.layout);

--- a/src/components/shop/shop.js
+++ b/src/components/shop/shop.js
@@ -41,7 +41,7 @@ export class Shop extends Screen {
         const confirm = createConfirm(this);
         const callback = confirm.prepTransaction;
 
-        const inventoryFilter = item => item.id !== this.config.currencyItemKey;
+        const inventoryFilter = item => item.id !== this.config.balance.value.key;
 
         this.panes = {
             top: createMenu(this),

--- a/src/components/shop/shop.js
+++ b/src/components/shop/shop.js
@@ -41,10 +41,12 @@ export class Shop extends Screen {
         const confirm = createConfirm(this);
         const callback = confirm.prepTransaction;
 
+        const inventoryFilter = item => item.id !== this.config.currencyItemKey;
+
         this.panes = {
             top: createMenu(this),
             shop: new ScrollableList(this, "shop", callback),
-            manage: new ScrollableList(this, "manage", callback),
+            manage: new ScrollableList(this, "manage", callback, inventoryFilter),
             confirm,
         };
         this.setVisiblePane("top");

--- a/src/components/shop/transact.js
+++ b/src/components/shop/transact.js
@@ -9,9 +9,11 @@ import { collections } from "../../core/collections.js";
 
 export const doTransaction = scene => tx => {
     const { shop, manage } = scene.config.paneCollections;
-    const currencyKey = scene.config.balance.value.key;
     const invCol = collections.get(manage);
-    return (tx.title === "shop" && buy(tx, shop, invCol, currencyKey)) || (tx.title === "manage" && equip(tx, invCol));
+    return (
+        (tx.title === "shop" && buy(tx, shop, invCol, scene.config.balance.value.key)) ||
+        (tx.title === "manage" && equip(tx, invCol))
+    );
 };
 
 const buy = (tx, shop, invCol, currencyKey) => {

--- a/src/components/shop/transact.js
+++ b/src/components/shop/transact.js
@@ -9,17 +9,25 @@ import { collections } from "../../core/collections.js";
 
 export const doTransaction = scene => tx => {
     const { shop, manage } = scene.config.paneCollections;
+    const currencyKey = scene.config.balance.value.key;
     const invCol = collections.get(manage);
-    return (tx.title === "shop" && buy(tx, shop, invCol)) || (tx.title === "manage" && equip(tx, invCol));
+    return (tx.title === "shop" && buy(tx, shop, invCol, currencyKey)) || (tx.title === "manage" && equip(tx, invCol));
 };
 
-const buy = (tx, shop, invCol) => {
+const buy = (tx, shop, invCol, currencyKey) => {
     const shopCol = collections.get(shop);
     shopCol.set({ ...tx.item, state: "owned", qty: -1 });
     invCol.set({ ...tx.item, qty: +1 });
+    updateBalance(invCol, currencyKey, tx.item.price);
     return tx.item.price;
 };
 
 const equip = (tx, invCol) => {
     invCol.set({ ...tx.item, state: "equipped" });
+};
+
+const updateBalance = (invCol, currencyKey, price) => {
+    const currency = invCol.get(currencyKey);
+    const newBalance = currency.qty - price;
+    invCol.set({ ...currency, qty: newBalance });
 };

--- a/src/core/layout/scrollable-list/scrollable-list.js
+++ b/src/core/layout/scrollable-list/scrollable-list.js
@@ -62,9 +62,7 @@ const createTable = (scene, title, prepTx, parent) => {
             name: "grid",
         });
 
-        collection.forEach((item, idx) =>
-            table.add(createItem(scene, item, title, prepTx), 0, idx, "top", 0, true),
-        );
+        collection.forEach((item, idx) => table.add(createItem(scene, item, title, prepTx), 0, idx, "top", 0, true));
 
         sizer.add(table, 1, "center", 0, true);
     }
@@ -131,7 +129,7 @@ const updatePanelList = panel => {
 
 const getPanelItems = panel => panel.getByName("grid", true)?.getElement("items") ?? [];
 
-const getFilteredCollection = (collection, filter) => filter ? collection.filter(filter) : collection;
+const getFilteredCollection = (collection, filter) => (filter ? collection.filter(filter) : collection);
 
 export class ScrollableList extends Phaser.GameObjects.Container {
     constructor(scene, title, callback, filter) {

--- a/test/components/shop/balance-ui.test.js
+++ b/test/components/shop/balance-ui.test.js
@@ -8,6 +8,7 @@
 import * as shopLayout from "../../../src/components/shop/shop-layout.js";
 import { createBalance } from "../../../src/components/shop/balance-ui.js";
 import * as scalerModule from "../../../src/core/scaler.js";
+import { collections } from "../../../src/core/collections.js";
 
 describe("createBalance()", () => {
     let balanceElem;
@@ -55,12 +56,13 @@ describe("createBalance()", () => {
                 },
                 value: {
                     type: "text",
-                    value: 1000,
+                    key: "someId",
                     styles: { foo: "bar" },
                 },
             },
             balancePadding: 6,
             listPadding: { x: 1 },
+            paneCollections: { manage: "inventory" },
         },
         layout: {
             getSafeArea: jest.fn(() => mockSafeArea),
@@ -68,6 +70,9 @@ describe("createBalance()", () => {
     };
     const mockMetrics = { foo: "bar" };
     scalerModule.getMetrics = jest.fn(() => mockMetrics);
+    const mockCurrencyItem = { id: "someId", qty: 100 };
+    const mockCollection = { getAll: jest.fn().mockReturnValue([mockCurrencyItem]) };
+    collections.get = jest.fn().mockReturnValue(mockCollection);
 
     beforeEach(() => {
         shopLayout.getXPos = jest.fn().mockReturnValue(42);
@@ -92,7 +97,7 @@ describe("createBalance()", () => {
             resolution: 4,
             foo: "bar",
         };
-        expect(mockScene.add.text).toHaveBeenCalledWith(0, 0, 1000, expectedStyles);
+        expect(mockScene.add.text).toHaveBeenCalledWith(0, 0, 100, expectedStyles);
     });
     test("positions the icon to the left", () => {
         expect(mockReturnedIcon.setPosition).toHaveBeenCalledWith(-12, 0);

--- a/test/components/shop/balance-ui.test.js
+++ b/test/components/shop/balance-ui.test.js
@@ -71,7 +71,7 @@ describe("createBalance()", () => {
     const mockMetrics = { foo: "bar" };
     scalerModule.getMetrics = jest.fn(() => mockMetrics);
     const mockCurrencyItem = { id: "someId", qty: 100 };
-    const mockCollection = { getAll: jest.fn().mockReturnValue([mockCurrencyItem]) };
+    const mockCollection = { get: jest.fn().mockReturnValue(mockCurrencyItem) };
     collections.get = jest.fn().mockReturnValue(mockCollection);
 
     beforeEach(() => {
@@ -97,7 +97,12 @@ describe("createBalance()", () => {
             resolution: 4,
             foo: "bar",
         };
-        expect(mockScene.add.text).toHaveBeenCalledWith(0, 0, 100, expectedStyles);
+        expect(mockScene.add.text.mock.calls[0][3]).toStrictEqual(expectedStyles);
+    });
+    test("uses the quantity of the currency item from inventory as its value", () => {
+        expect(collections.get).toHaveBeenCalledWith("inventory");
+        expect(mockCollection.get).toHaveBeenCalledWith("someId");
+        expect(mockScene.add.text.mock.calls[0][2]).toStrictEqual(mockCurrencyItem.qty);
     });
     test("positions the icon to the left", () => {
         expect(mockReturnedIcon.setPosition).toHaveBeenCalledWith(-12, 0);

--- a/test/components/shop/shop.test.js
+++ b/test/components/shop/shop.test.js
@@ -21,8 +21,7 @@ describe("Shop", () => {
     const mockScrollableList = { setVisible: jest.fn() };
     const config = {
         shop: {
-            title: [],
-            balance: [],
+            balance: { value: { key: "currencyItemKey" } },
             assetKeys: {
                 prefix: "shop",
                 background: "background",
@@ -119,9 +118,15 @@ describe("Shop", () => {
         });
 
         test("adds scrollable list panes", () => {
-            expect(ScrollableList).toHaveBeenCalled();
+            expect(ScrollableList).toHaveBeenCalledTimes(2);
             expect(shopScreen.panes.shop).toBe(mockScrollableList);
             expect(shopScreen.panes.manage).toBe(mockScrollableList);
+        });
+
+        test("passes a filter function to the inventory pane", () => {
+            const filterFn = ScrollableList.mock.calls[1][3];
+            const mockCollection = [{ id: "currencyItemKey" }, { id: "someOtherId" }];
+            expect(mockCollection.filter(filterFn)).toStrictEqual([{ id: "someOtherId" }]);
         });
 
         test("calls createTitle to create the title UI component", () => {

--- a/test/components/shop/transact.test.js
+++ b/test/components/shop/transact.test.js
@@ -13,7 +13,6 @@ describe("doTransaction", () => {
     let result;
     let doTransaction;
 
-    
     const mockCurrencyItem = { id: "someId", qty: 100 };
     const mockScene = {
         config: { paneCollections: { shop: "shop", manage: "manage" }, balance: { value: { key: "currencyKey" } } },
@@ -40,8 +39,10 @@ describe("doTransaction", () => {
         test("processes a buy transaction", () => {
             const expectedShopSet = { ...mockItem, state: "owned", qty: -1 };
             expect(mockShopCol.set.mock.calls[0][0]).toStrictEqual(expectedShopSet);
-            const expectedInvSet = { ...mockItem, qty: +1 };
-            expect(mockInvCol.set.mock.calls[0][0]).toStrictEqual(expectedInvSet);
+            const expectedBoughtItemSet = { ...mockItem, qty: 1 };
+            expect(mockInvCol.set.mock.calls[0][0]).toStrictEqual(expectedBoughtItemSet);
+            const expectedCurrencySet = { ...mockCurrencyItem, qty: 50 };
+            expect(mockInvCol.set.mock.calls[1][0]).toStrictEqual(expectedCurrencySet);
         });
         test("returns the price that was charged", () => {
             expect(result).toBe(50);

--- a/test/components/shop/transact.test.js
+++ b/test/components/shop/transact.test.js
@@ -13,11 +13,13 @@ describe("doTransaction", () => {
     let result;
     let doTransaction;
 
+    
+    const mockCurrencyItem = { id: "someId", qty: 100 };
     const mockScene = {
-        config: { paneCollections: { shop: "shop", manage: "manage" } },
+        config: { paneCollections: { shop: "shop", manage: "manage" }, balance: { value: { key: "currencyKey" } } },
     };
     const mockShopCol = { set: jest.fn(), get: jest.fn().mockReturnValue("baz") };
-    const mockInvCol = { set: jest.fn() };
+    const mockInvCol = { set: jest.fn(), get: jest.fn().mockReturnValue(mockCurrencyItem) };
     const mockItem = { id: "someItem", price: 50 };
 
     beforeEach(() => {

--- a/test/core/layout/scrollable-list/scrollable-list.test.js
+++ b/test/core/layout/scrollable-list/scrollable-list.test.js
@@ -334,4 +334,13 @@ describe("Scrollable List", () => {
             expect(collections.get).not.toHaveBeenCalled();
         });
     });
+    describe("collection filtering", () => {
+        const filterFn = jest.fn().mockReturnValue(true);
+
+        beforeEach(() => new ScrollableList(mockScene, "title", fp.noop, filterFn));
+
+        test("if a filter function is passed to the list, it is run against the collection", () => {
+            expect(filterFn).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/themes/default/items/game-items.json5
+++ b/themes/default/items/game-items.json5
@@ -34,5 +34,13 @@
         title: "Banana",
         description: "A ripe banana",
         tags: ["food"],
-    }
+    },
+    {
+        id: "coin",
+        title: "Coins",
+        description: "Money",
+        longDescription: "AKA cash, moolah, \nscratch, dough, bread...",
+        icon: "balanceIcon",
+        tags: ["currency"],
+    },
 ]

--- a/themes/default/items/inventory.json5
+++ b/themes/default/items/inventory.json5
@@ -3,7 +3,7 @@
     include: ["starter-item"], //include all items with this tag in this collection
     defaultQty: 0, //default quantity unless specified
     defaults: [
-        { id: "box", qty: 1 },
+        { id: "box", qty: 1, state: "owned" },
         { id: "coin", qty: 10 },
     ],
 }

--- a/themes/default/items/inventory.json5
+++ b/themes/default/items/inventory.json5
@@ -1,8 +1,9 @@
 {
-    catalogue: "game-items",    //catalogue array or string filename of json5 catalogue
-    include: ["starter-item"],        //include all items with this tag in this collection
-    defaultQty: 0,              //default quantity unless specified
-    defaults: [                 //additional config
+    catalogue: "game-items", //catalogue array or string filename of json5 catalogue
+    include: ["starter-item"], //include all items with this tag in this collection
+    defaultQty: 0, //default quantity unless specified
+    defaults: [
         { id: "box", qty: 1 },
+        { id: "coin", qty: 10 },
     ],
 }


### PR DESCRIPTION
- relevant code now uses the quantity of a nominated inventory item as currency
- currency item is filtered out of the scrollable list
- transactions update the quantity of that nominated item in the inventory collection
- panel updating checks against the filtered collection