### PR TITLE
[CGPROD-2844] Allow debug screens to be hidden

### DIFF
--- a/src/core/debug/launcher.js
+++ b/src/core/debug/launcher.js
@@ -56,6 +56,8 @@ const titleStyle = {
     align: "center",
 };
 
+const excludeHidden = key => !examples[key].hidden;
+
 export class Launcher extends Screen {
     create() {
         addExampleScreens(this);
@@ -67,6 +69,6 @@ export class Launcher extends Screen {
 
         this.sound.pauseOnBlur = false;
 
-        Object.keys(examples).map(getButtonConfig(this)).map(addButton);
+        Object.keys(examples).filter(excludeHidden).map(getButtonConfig(this)).map(addButton);
     }
 }


### PR DESCRIPTION
- Debug launcher filters out screens from examples.js that have a property `hidden: true`
- These screens are still available to route to, so we can now build more complex flows inside debug.