### PR TITLE
[CGPROD-2962] fix buttonsRight config

### DIFF
--- a/src/components/shop/confirm.js
+++ b/src/components/shop/confirm.js
@@ -37,11 +37,11 @@ export const createConfirm = scene => {
     container.elems = {
         background: [createRect(scene, innerBounds, 0x0000ff), createPaneBackground(scene, bounds, "confirm")],
         prompt: scene.add
-            .text(innerBounds.x, promptY(bounds), config.confirm.prompts.shop, styleDefaults)
+            .text(getX(innerBounds.x, config), promptY(bounds), config.confirm.prompts.shop, styleDefaults)
             .setOrigin(0.5),
-        price: scene.add.text(innerBounds.x + 28, currencyY(bounds), "PH", styleDefaults).setOrigin(0.5),
+        price: scene.add.text(getX(innerBounds.x + 28, config), currencyY(bounds), "PH", styleDefaults).setOrigin(0.5),
         priceIcon: scene.add.image(
-            innerBounds.x - 20,
+            getX(innerBounds.x - 20, config),
             currencyY(bounds),
             `${config.assetPrefix}.${config.assetKeys.currency}`,
         ),
@@ -138,6 +138,7 @@ const getItemDescription = item => (item ? item.description : "Item Default Desc
 const getItemBlurb = item => (item ? item.longDescription : "");
 const assetKey = (config, item) => (item ? `${config.assetPrefix}.${item.icon}` : "shop.itemIcon");
 const imageY = bounds => -bounds.height / 4;
+const getX = (x, config) => (config.menu.buttonsRight ? x : -x);
 const promptY = outerBounds => -outerBounds.height * (3 / 8);
 const currencyY = outerBounds => -outerBounds.height / 4;
 const blurbY = bounds => bounds.height / 4;

--- a/src/components/shop/menu-buttons.js
+++ b/src/components/shop/menu-buttons.js
@@ -50,7 +50,8 @@ const resizeButton = container => (button, idx) => {
     const right = Boolean(container.scene.config.menu.buttonsRight);
     const bounds = container.list[0].getBounds();
     button.setY(CAMERA_Y + bounds.y + bounds.height / 4 + (idx * bounds.height) / 2);
-    button.setX(CAMERA_X + (right ? bounds.x + bounds.width / 2 : -bounds.x));
+    const xPos = bounds.x + bounds.width / 2;
+    button.setX(CAMERA_X + (right ? xPos : -xPos));
     button.setScale(bounds.width / button.width);
 };
 

--- a/test/components/shop/confirm.test.js
+++ b/test/components/shop/confirm.test.js
@@ -102,7 +102,7 @@ describe("createConfirm()", () => {
         jest.clearAllMocks();
         mockScene.config = { ...mockConfig, menu: { buttonsRight: false } };
         createConfirm(mockScene);
-        expect(mockScene.add.text).toHaveBeenCalledWith(28, -25, "PH", {});
+        expect(mockScene.add.text).toHaveBeenCalledWith(-28, -25, "PH", {});
     });
     test("that is displayed with an appropriate Y offset", () => {
         expect(mockContainer.setY).toHaveBeenCalledWith(55);

--- a/test/components/shop/menu-buttons.test.js
+++ b/test/components/shop/menu-buttons.test.js
@@ -181,11 +181,11 @@ describe("shop menu buttons", () => {
             expect(mockButton.setScale).toHaveBeenCalledWith(4);
         });
         describe("when buttonsRight is false", () => {
-            test("the x position is further left", () => {
+            test("the x position is mirrored", () => {
                 jest.clearAllMocks();
                 container.scene.config.menu.buttonsRight = false;
                 resizeGelButtons(container, mockOuterBounds);
-                expect(mockButton.setX.mock.calls[0][0]).toBe(700);
+                expect(mockButton.setX.mock.calls[0][0]).toBe(300);
             });
         });
     });


### PR DESCRIPTION
- x position of shop menu buttons was being calculated wrong- fixed
- x-position for confirm price icon, text and prompt were not being flipped on `buttonsRight : false` - fixed.