### PR TITLE
[CGPROD-2981] fix tab order on shop pane navigation 

### DIFF
--- a/src/components/shop/shop.js
+++ b/src/components/shop/shop.js
@@ -14,6 +14,7 @@ import { createMenu } from "./menu.js";
 import { getSafeArea, getXPos, getYPos, getScaleFactor } from "./shop-layout.js";
 import { eventBus } from "../../core/event-bus.js";
 import { createConfirm } from "./confirm.js";
+import * as a11y from "../../core/accessibility/accessibility-layer.js";
 
 const memoizeBackButton = config => (({ channel, key, action }) => ({ channel, name: key, callback: action }))(config);
 
@@ -60,6 +61,7 @@ export class Shop extends Screen {
         this.paneStack.push(pane);
         this.setVisiblePane(pane);
         this.paneStack.length === 1 && this.useCustomMessage();
+        a11y.reset();
     }
 
     back() {

--- a/test/components/shop/shop.test.js
+++ b/test/components/shop/shop.test.js
@@ -12,6 +12,7 @@ import * as titles from "../../../src/components/shop/shop-titles.js";
 import * as uiScaler from "../../../src/components/shop/shop-layout.js";
 import * as menu from "../../../src/components/shop/menu.js";
 import * as confirm from "../../../src/components/shop/confirm.js";
+import * as a11y from "../../../src/core/accessibility/accessibility-layer.js";
 import { eventBus } from "../../../src/core/event-bus.js";
 
 jest.mock("../../../src/core/layout/scrollable-list/scrollable-list.js");
@@ -88,6 +89,7 @@ describe("Shop", () => {
         menu.createMenu = jest.fn().mockReturnValue(mockMenu);
         eventBus.subscribe = jest.fn();
         eventBus.removeSubscription = jest.fn();
+        a11y.reset = jest.fn();
     });
 
     afterEach(() => jest.clearAllMocks());
@@ -196,6 +198,9 @@ describe("Shop", () => {
             });
             test("sets that pane visible", () => {
                 expect(shopScreen.panes.shop.setVisible).toHaveBeenCalledWith(true);
+            });
+            test("resets a11y", () => {
+                expect(a11y.reset).toHaveBeenCalled();
             });
             test("on starting the stack, changes the event subscription", () => {
                 expect(eventBus.subscribe).toHaveBeenCalledWith(shopScreen.customMessage);


### PR DESCRIPTION
- Add a11y.reset call on changing panes, update tests.
- Tested with keyboard tabbing and VoiceOver
- some oddness with highlighting on VoiceOver, but this appears to be coming from the rexUI plugin- may not be in our gift to fix. However, the voiceover is consistent with our other pages, and tabbing definitely works nicely.