### PR TITLE
[CGPROD-2978] fix resize crash after using a screen with a scrollable list

### DIFF
--- a/src/core/layout/scrollable-list/scrollable-list.js
+++ b/src/core/layout/scrollable-list/scrollable-list.js
@@ -97,7 +97,7 @@ const createItem = (scene, item, title, prepTx) => {
 };
 
 const resizePanel = (scene, panel) => () => {
-    const t = panel.t;
+    const t = panel.t; // here's our crash root cause- crash is thrown from inside rexUI tho.
     const items = getPanelItems(panel);
     items.forEach(label => scaleButton(label.children[0], scene.layout, scene.config.listPadding));
     const safeArea = getPanelY(scene);
@@ -113,7 +113,9 @@ const setupEvents = (scene, panel) => {
     const scaleEvent = onScaleChange.add(resizePanel(scene, panel));
     scene.events.once("shutdown", scaleEvent.unsubscribe);
 
-    scene.scale.on("resize", fp.debounce(10, resizePanel(scene, panel)), scene);
+    const debouncedResize = fp.debounce(10, resizePanel(scene, panel));
+    scene.scale.on("resize", debouncedResize, scene);
+    scene.events.once("shutdown", () => scene.scale.removeListener("resize", debouncedResize));
 
     panel.updateOnScroll = updatePanelOnScroll(panel);
     panel.on("scroll", panel.updateOnScroll);

--- a/src/core/layout/scrollable-list/scrollable-list.js
+++ b/src/core/layout/scrollable-list/scrollable-list.js
@@ -97,7 +97,7 @@ const createItem = (scene, item, title, prepTx) => {
 };
 
 const resizePanel = (scene, panel) => () => {
-    const t = panel.t; // here's our crash root cause- crash is thrown from inside rexUI tho.
+    const t = panel.t;
     const items = getPanelItems(panel);
     items.forEach(label => scaleButton(label.children[0], scene.layout, scene.config.listPadding));
     const safeArea = getPanelY(scene);

--- a/test/core/layout/scrollable-list/scrollable-list.test.js
+++ b/test/core/layout/scrollable-list/scrollable-list.test.js
@@ -109,7 +109,7 @@ describe("Scrollable List", () => {
                 getSafeArea: jest.fn().mockReturnValue({ y: 0, x: 0, width: 100, height: 100 }),
                 addCustomGroup: jest.fn(),
             },
-            scale: { on: jest.fn() },
+            scale: { on: jest.fn(), removeListener: jest.fn() },
             scene: { key: "shop" },
             sys: {
                 queueDepthSort: jest.fn(),
@@ -276,6 +276,14 @@ describe("Scrollable List", () => {
                 expect(mockA11yElem.addEventListener.mock.calls[0][0]).toBe("focus");
                 mockA11yElem.addEventListener.mock.calls[0][1]();
                 expect(mockScrollablePanel.updateOnFocus).toHaveBeenCalled();
+            });
+        });
+        describe("shutdown", () => {
+            test("calls removeListener with the debounced resize listener", () => {
+                new ScrollableList(mockScene);
+                const shutdownListener = mockScene.events.once.mock.calls[1][1];
+                shutdownListener();
+                expect(mockScene.scale.removeListener).toHaveBeenCalled();
             });
         });
     });


### PR DESCRIPTION
- To get resize working nicely scrollable-list needed to be resized twice- once by the scaler (`onScaleChange.add()`) and once by Phaser (`scene.events.on("resize", [fn])`) - this resolved an issue with RexUI not playing nicely with our scaler.
- We weren't removing the scene.events.on listener, resulting in an NPE on resize once the user had visited the shop.
- Added a shutdown listener that unsubs from the Phaser event, resolving the NPE.
- Add test.