### PR TITLE
NOTICKET debug collection Fixes

### DIFF
--- a/src/core/collections.js
+++ b/src/core/collections.js
@@ -40,7 +40,7 @@ export const initCollection = screen => key => {
 
     const storagePath = ["collections", key];
     const catalogue = fp.isString(config.catalogue)
-        ? screen.cache.json.get(`$items/${config.catalogue}`)
+        ? screen.cache.json.get(`items/${config.catalogue}`)
         : config.catalogue;
 
     const valid = validateFn(catalogue);

--- a/src/core/collections.js
+++ b/src/core/collections.js
@@ -34,13 +34,13 @@ const validateFn = catalogue =>
         [fp.stubTrue, fp.stubTrue],
     ]);
 
-export const initCollection = (screen, path = "") => key => {
+export const initCollection = screen => key => {
     const getStored = getStoredFn(key);
-    const config = screen.cache.json.get(`${path}items/${key}`);
+    const config = screen.cache.json.get(`items/${key}`);
 
     const storagePath = ["collections", key];
     const catalogue = fp.isString(config.catalogue)
-        ? screen.cache.json.get(`${path}items/${config.catalogue}`)
+        ? screen.cache.json.get(`$items/${config.catalogue}`)
         : config.catalogue;
 
     const valid = validateFn(catalogue);

--- a/src/core/debug/debug-mode.js
+++ b/src/core/debug/debug-mode.js
@@ -10,12 +10,11 @@ import { collections } from "../collections.js";
 const urlParams = window => parseUrlParams(window.location.search);
 const testURL = window => window.location.hostname.includes("www.test.bbc.");
 
-const create = window => {
+export const create = window => {
     if (isDebug() || testURL(window)) {
-        window.__debug = { gmi, collections };
+        const debugParam = urlParams(window).debug
+        window.__debug = { gmi, collections, debugParam };
     }
 };
 
-const isDebug = () => Boolean(urlParams(window).debug);
-
-export { isDebug, create };
+export const isDebug = () => Boolean(urlParams(window).debug);

--- a/src/core/debug/debug-mode.js
+++ b/src/core/debug/debug-mode.js
@@ -12,7 +12,7 @@ const testURL = window => window.location.hostname.includes("www.test.bbc.");
 
 export const create = window => {
     if (isDebug() || testURL(window)) {
-        const debugParam = urlParams(window).debug
+        const debugParam = urlParams(window).debug;
         window.__debug = { gmi, collections, debugParam };
     }
 };

--- a/src/core/debug/debug-screens.js
+++ b/src/core/debug/debug-screens.js
@@ -9,7 +9,6 @@ import { getConfig } from "../loader/get-config.js";
 import fp from "../../../lib/lodash/fp/fp.js";
 import { loadCollections } from "../loader/load-collections.js";
 import { gmi } from "../gmi/gmi.js";
-import { getTheme } from "../get-theme.js";
 
 const launcherScreen = {
     debug: {
@@ -27,7 +26,6 @@ const getDebugScreenWithRoutes = () => {
 
 const addScene = (scene, examples) => key => scene.scene.add(key, examples[key].scene);
 
-/* istanbul ignore next */
 const addScreens = async scene => {
     Object.keys(examples).map(addScene(scene, examples));
     const debugTheme = getConfig(scene, Object.keys(examples));
@@ -39,10 +37,10 @@ const addScreens = async scene => {
 
     scene.setConfig(config);
 
-    this.load.setBaseURL(gmi.gameDir);
-    this.load.setPath("debug/");
+    scene.load.setBaseURL(gmi.gameDir);
+    scene.load.setPath("debug/");
 
-    await loadCollections(scene, debugTheme);
+    await loadCollections(scene, debugTheme, "debug/");
 };
 
 export const addExampleScreens = fp.once(addScreens);

--- a/src/core/debug/debug-screens.js
+++ b/src/core/debug/debug-screens.js
@@ -8,6 +8,8 @@ import { examples } from "./examples.js";
 import { getConfig } from "../loader/get-config.js";
 import fp from "../../../lib/lodash/fp/fp.js";
 import { loadCollections } from "../loader/load-collections.js";
+import { gmi } from "../gmi/gmi.js";
+import { getTheme } from "../get-theme.js";
 
 const launcherScreen = {
     debug: {
@@ -35,7 +37,11 @@ const addScreens = async scene => {
     Object.assign(config.navigation, examples);
 
     scene.setConfig(config);
-    await loadCollections(scene, debugTheme, "debug/");
+
+    this.load.setBaseURL(gmi.gameDir);
+    this.load.setPath("debug/");
+
+    await loadCollections(scene, debugTheme);
 };
 
 export const addExampleScreens = fp.once(addScreens);

--- a/src/core/debug/debug-screens.js
+++ b/src/core/debug/debug-screens.js
@@ -27,6 +27,7 @@ const getDebugScreenWithRoutes = () => {
 
 const addScene = (scene, examples) => key => scene.scene.add(key, examples[key].scene);
 
+/* istanbul ignore next */
 const addScreens = async scene => {
     Object.keys(examples).map(addScene(scene, examples));
     const debugTheme = getConfig(scene, Object.keys(examples));

--- a/src/core/loader/load-collections.js
+++ b/src/core/loader/load-collections.js
@@ -10,7 +10,6 @@ const getKey = item => item.collection;
 const loadToCache = screen => key => screen.load.json5({ key: `items/${key}`, url: `items/${key}.json5` });
 const getKeys = config => Object.values(config).map(getKey).filter(Boolean);
 
-/* istanbul ignore next */
 export const loadCollections = (screen, config) => {
     const keys = getKeys(config).flat();
     keys.forEach(loadToCache(screen));

--- a/src/core/loader/load-collections.js
+++ b/src/core/loader/load-collections.js
@@ -10,6 +10,7 @@ const getKey = item => item.collection;
 const loadToCache = screen => key => screen.load.json5({ key: `items/${key}`, url: `items/${key}.json5` });
 const getKeys = config => Object.values(config).map(getKey).filter(Boolean);
 
+/* istanbul ignore next */
 export const loadCollections = (screen, config) => {
     const keys = getKeys(config).flat();
     keys.forEach(loadToCache(screen));

--- a/src/core/loader/load-collections.js
+++ b/src/core/loader/load-collections.js
@@ -7,25 +7,24 @@ import { initCollection } from "../collections.js";
 import fp from "../../../lib/lodash/fp/fp.js";
 
 const getKey = item => item.collection;
-const loadToCache = (screen, path) => key =>
-    screen.load.json5({ key: `${path}items/${key}`, url: `${path}items/${key}.json5` });
+const loadToCache = screen => key => screen.load.json5({ key: `items/${key}`, url: `items/${key}.json5` });
 const getKeys = config => Object.values(config).map(getKey).filter(Boolean);
 
-export const loadCollections = (screen, config, path = "") => {
+export const loadCollections = (screen, config) => {
     const keys = getKeys(config).flat();
-    keys.forEach(loadToCache(screen, path));
+    keys.forEach(loadToCache(screen));
 
     return new Promise(resolve => {
         const cataloguesLoaded = () => {
-            keys.forEach(initCollection(screen, path));
+            keys.forEach(initCollection(screen));
             resolve();
         };
 
         const collectionsLoaded = () => {
             const catalogueKeys = fp
-                .uniq(keys.map(key => screen.cache.json.get(`${path}items/${key}`).catalogue))
+                .uniq(keys.map(key => screen.cache.json.get(`items/${key}`).catalogue))
                 .filter(fp.isString);
-            catalogueKeys.forEach(loadToCache(screen, path));
+            catalogueKeys.forEach(loadToCache(screen));
             screen.load.once("complete", cataloguesLoaded);
             screen.load.start();
         };

--- a/src/core/loader/loader.js
+++ b/src/core/loader/loader.js
@@ -78,7 +78,7 @@ export class Loader extends Screen {
             this._loadbar.frame.cutWidth = this._loadbar.width * progress;
             this._loadbar.frame.updateUVs();
         }
-        if (window.__debug) {
+        if (window.__debug && window.__debug.debugParam !== "nolog") {
             console.log("Loader progress:", progress); // eslint-disable-line no-console
         }
     };

--- a/test/core/collections.test.js
+++ b/test/core/collections.test.js
@@ -68,12 +68,6 @@ describe("Collections", () => {
             expect(collections.get("testCollection")).toBeDefined();
         });
 
-        test("adds an entry to the collections map when a path is provided", () => {
-            mockCache["debug/items/testCollection2"] = testCollection;
-            initCollection(mockScreen, "debug/")("testCollection2");
-            expect(collections.get("testCollection2")).toBeDefined();
-        });
-
         test("returns an object with get, getAll and set access functions", () => {
             const collection = initCollection(mockScreen)("testCollection");
 
@@ -84,7 +78,7 @@ describe("Collections", () => {
     });
 
     describe("Returned getAll method", () => {
-        test("Returns all catalogue fromn json cache if string specified", () => {
+        test("Returns all catalogues from json cache if string specified", () => {
             const collection = initCollection(mockScreen)("testCollection");
             const expected = testCatalogue.map(item => ({ ...item, qty: 1 }));
 

--- a/test/core/debug/debug-mode.test.js
+++ b/test/core/debug/debug-mode.test.js
@@ -8,7 +8,7 @@ import * as parseUrlParams from "../../../src/core/parse-url-params.js";
 
 describe("Debug Mode", () => {
     const game = {};
-    const debugWindowKeys = ["gmi", "collections"];
+    const debugWindowKeys = ["gmi", "collections", "debugParam"];
 
     let testWindow = {
         location: {

--- a/test/core/debug/debug-screens.test.js
+++ b/test/core/debug/debug-screens.test.js
@@ -44,20 +44,20 @@ describe("getDebugScreens", () => {
 
         afterEach(jest.clearAllMocks);
 
-        test("gets and sets config for all example screens", () => {
-            addExampleScreens(mockScreen);
-            expect(mockScreen.scene.add).toHaveBeenCalled();
-            expect(Config.getConfig).toHaveBeenCalledWith(mockScreen, Object.keys(Examples.examples));
-            expect(mockScreen.setConfig.mock.calls[0][0]).toEqual({
-                navigation: { "debug-mockKey1": "", "debug-mockKey2": "", "debug-mockKey3": "" },
-                screen: "mockConfig",
-            });
-            expect(Load.loadCollections).toHaveBeenCalledWith(mockScreen, { screen: "mockConfig" }, "debug/");
-        });
+        //test("gets and sets config for all example screens", () => {
+        //    addExampleScreens(mockScreen);
+        //    expect(mockScreen.scene.add).toHaveBeenCalled();
+        //    expect(Config.getConfig).toHaveBeenCalledWith(mockScreen, Object.keys(Examples.examples));
+        //    expect(mockScreen.setConfig.mock.calls[0][0]).toEqual({
+        //        navigation: { "debug-mockKey1": "", "debug-mockKey2": "", "debug-mockKey3": "" },
+        //        screen: "mockConfig",
+        //    });
+        //    expect(Load.loadCollections).toHaveBeenCalledWith(mockScreen, { screen: "mockConfig" }, "debug/");
+        //});
 
-        test("Does not call a second time (fp.once)", () => {
-            addExampleScreens(mockScreen);
-            expect(mockScreen.setConfig).not.toHaveBeenCalled();
-        });
+        //test("Does not call a second time (fp.once)", () => {
+        //    addExampleScreens(mockScreen);
+        //    expect(mockScreen.setConfig).not.toHaveBeenCalled();
+        //});
     });
 });

--- a/test/core/debug/debug-screens.test.js
+++ b/test/core/debug/debug-screens.test.js
@@ -36,6 +36,10 @@ describe("getDebugScreens", () => {
                     config: {},
                     navigation: {},
                 },
+                load: {
+                    setBaseURL: jest.fn(),
+                    setPath: jest.fn(),
+                },
                 scene: {
                     add: jest.fn(),
                 },
@@ -44,20 +48,21 @@ describe("getDebugScreens", () => {
 
         afterEach(jest.clearAllMocks);
 
-        //test("gets and sets config for all example screens", () => {
-        //    addExampleScreens(mockScreen);
-        //    expect(mockScreen.scene.add).toHaveBeenCalled();
-        //    expect(Config.getConfig).toHaveBeenCalledWith(mockScreen, Object.keys(Examples.examples));
-        //    expect(mockScreen.setConfig.mock.calls[0][0]).toEqual({
-        //        navigation: { "debug-mockKey1": "", "debug-mockKey2": "", "debug-mockKey3": "" },
-        //        screen: "mockConfig",
-        //    });
-        //    expect(Load.loadCollections).toHaveBeenCalledWith(mockScreen, { screen: "mockConfig" }, "debug/");
-        //});
+        test("gets and sets config for all example screens", () => {
+            addExampleScreens(mockScreen);
+            expect(mockScreen.scene.add).toHaveBeenCalled();
+            expect(Config.getConfig).toHaveBeenCalledWith(mockScreen, Object.keys(Examples.examples));
+            expect(mockScreen.setConfig.mock.calls[0][0]).toEqual({
+                navigation: { "debug-mockKey1": "", "debug-mockKey2": "", "debug-mockKey3": "" },
+                screen: "mockConfig",
+            });
 
-        //test("Does not call a second time (fp.once)", () => {
-        //    addExampleScreens(mockScreen);
-        //    expect(mockScreen.setConfig).not.toHaveBeenCalled();
-        //});
+            expect(Load.loadCollections).toHaveBeenCalledWith(mockScreen, { screen: "mockConfig" }, "debug/");
+        });
+
+        test("Does not call a second time (fp.once)", () => {
+            addExampleScreens(mockScreen);
+            expect(mockScreen.setConfig).not.toHaveBeenCalled();
+        });
     });
 });

--- a/test/core/loader/load-collections.test.js
+++ b/test/core/loader/load-collections.test.js
@@ -53,24 +53,24 @@ describe("loadCollections", () => {
         });
 
         test("Adds the correct collection file urls to the loader when custom path given", () => {
-            loadCollections(mockScreen, mockConfig, "somepath/");
-            expect(mockScreen.load.json5.mock.calls[0][0].key).toEqual("somepath/items/collection1");
-            expect(mockScreen.load.json5.mock.calls[1][0].key).toEqual("somepath/items/collection2");
+            loadCollections(mockScreen, mockConfig);
+            expect(mockScreen.load.json5.mock.calls[0][0].key).toEqual("items/collection1");
+            expect(mockScreen.load.json5.mock.calls[1][0].key).toEqual("items/collection2");
 
-            expect(mockScreen.load.json5.mock.calls[0][0].url).toEqual("somepath/items/collection1.json5");
-            expect(mockScreen.load.json5.mock.calls[1][0].url).toEqual("somepath/items/collection2.json5");
+            expect(mockScreen.load.json5.mock.calls[0][0].url).toEqual("items/collection1.json5");
+            expect(mockScreen.load.json5.mock.calls[1][0].url).toEqual("items/collection2.json5");
         });
 
         test("a screen can initialise an array of collections", () => {
             mockConfig.screen2.collection = ["collection2", "collection3"];
-            loadCollections(mockScreen, mockConfig, "somepath/");
-            expect(mockScreen.load.json5.mock.calls[0][0].key).toEqual("somepath/items/collection1");
-            expect(mockScreen.load.json5.mock.calls[1][0].key).toEqual("somepath/items/collection2");
-            expect(mockScreen.load.json5.mock.calls[2][0].key).toEqual("somepath/items/collection3");
+            loadCollections(mockScreen, mockConfig);
+            expect(mockScreen.load.json5.mock.calls[0][0].key).toEqual("items/collection1");
+            expect(mockScreen.load.json5.mock.calls[1][0].key).toEqual("items/collection2");
+            expect(mockScreen.load.json5.mock.calls[2][0].key).toEqual("items/collection3");
 
-            expect(mockScreen.load.json5.mock.calls[0][0].url).toEqual("somepath/items/collection1.json5");
-            expect(mockScreen.load.json5.mock.calls[1][0].url).toEqual("somepath/items/collection2.json5");
-            expect(mockScreen.load.json5.mock.calls[2][0].url).toEqual("somepath/items/collection3.json5");
+            expect(mockScreen.load.json5.mock.calls[0][0].url).toEqual("items/collection1.json5");
+            expect(mockScreen.load.json5.mock.calls[1][0].url).toEqual("items/collection2.json5");
+            expect(mockScreen.load.json5.mock.calls[2][0].url).toEqual("items/collection3.json5");
         });
 
         test("Adds the correct catalogue file urls to the loader", () => {


### PR DESCRIPTION
* Fix the pathing issue.
* Also add `debug=nolog` option to remove loader log that only QA use