### PR TITLE
[CGPPROD-2963] improve shop item information architecture and rationalise config

### DIFF
--- a/debug/examples/shop-demo-shop.json5
+++ b/debug/examples/shop-demo-shop.json5
@@ -14,7 +14,7 @@
     styleDefaults: {
         fontFamily: "ReithSans",
         fontSize: "24px",
-        resolution: 5,
+        resolution: 10,
         align: "center",
     },
     titles: [

--- a/debug/examples/shop-demo-shop.json5
+++ b/debug/examples/shop-demo-shop.json5
@@ -11,6 +11,12 @@
     background: {
         items: [{ key: "shop.magicShop", x: 0, y: 0 }],
     },
+    styleDefaults: {
+        fontFamily: "ReithSans",
+        fontSize: "24px",
+        resolution: 5,
+        align: "center",
+    },
     titles: [
         {
             type: "image",
@@ -23,10 +29,7 @@
             value: "Shop",
             xOffset: 0,
             yOffset: 0,
-            styles: {
-                fontSize: "24px",
-                resolution: 4,
-            },
+            styles: { fontSize: 24 },
         },
     ],
     titlePadding: 20,
@@ -42,7 +45,6 @@
         value: {
             type: "text",
             key: "coin", // the id of the currency item, which must exist in the inventory collection
-            styles: {},
         },
     },
     balancePadding: 15,
@@ -58,16 +60,15 @@
     },
     confirm: {
         detailView: true, // true === smaller image and more text. false === large image only.
-        prompts: {
+        prompt: {
             shop: { legal: "Purchase this item?", illegal: "You can't afford this." },
             manage: { legal: "Do you want to \nequip this item?", illegal: "You've already \nequipped this." },
+            // styles: {},
         },
-    },
-    styleDefaults: {
-        fontFamily: "ReithSans",
-        fontSize: "24px",
-        resolution: 5,
-        align: "center",
+        // title: { styles: {} }, // optionally configure styles on item text
+        detail: { styles: { color: "#2b2", fontStyle: "italic" } },
+        // description: { styles: {} },
+        // price: { styles: {} },
     },
     menu: {
         buttonsRight: true, // set as false to X-flip the menu layout
@@ -110,7 +111,7 @@
                 value: "title",
                 isDynamic: true,
                 position: { align: "left", offsetX: 80, offsetY: -18 },
-                font: { fontFamily: "ReithSans", resolution: 5, fontSize: 18 },
+                styles: { fontSize: 18 },
             },
             {
                 type: "text",
@@ -118,7 +119,7 @@
                 value: "description",
                 isDynamic: true,
                 position: { align: "left", offsetX: 80, offsetY: 4 },
-                font: { fontFamily: "ReithSans", resolution: 5, fontSize: 12 },
+                styles: { fontSize: 12 },
             },
         ],
         options: {
@@ -129,7 +130,7 @@
                     value: "price",
                     isDynamic: true,
                     position: { align: "right", offsetX: -44, offsetY: -10 },
-                    font: { fontFamily: "ReithSans", resolution: 5, fontSize: 14 },
+                    styles: { fontSize: 14 },
                     activeStates: ["cta"],
                 },
                 {
@@ -146,7 +147,7 @@
                     value: "Owned",
                     isDynamic: false,
                     position: { align: "right", offsetX: -76, offsetY: -10 },
-                    font: { fontFamily: "ReithSans", resolution: 5 },
+                    styles: { fontSize: 18 },
                     activeStates: ["actioned"],
                 },
             ],
@@ -157,7 +158,7 @@
                     value: "Equip",
                     isDynamic: false,
                     position: { align: "right", offsetX: -76, offsetY: -10 },
-                    font: { fontFamily: "ReithSans", resolution: 5 },
+                    styles: { fontSize: 18 },
                     activeStates: ["cta"],
                 },
                 {
@@ -166,7 +167,7 @@
                     value: "Equipped",
                     isDynamic: false,
                     position: { align: "right", offsetX: -88, offsetY: -10 },
-                    font: { fontFamily: "ReithSans", resolution: 5 },
+                    styles: { fontSize: 18 },
                     activeStates: ["actioned"],
                 },
             ],

--- a/debug/examples/shop-demo-shop.json5
+++ b/debug/examples/shop-demo-shop.json5
@@ -1,3 +1,4 @@
+// see debug/examples/shop.json5 for explanation of config
 {
     debugLabels: [
         {
@@ -44,7 +45,7 @@
         },
         value: {
             type: "text",
-            key: "coin", // the id of the currency item, which must exist in the inventory collection
+            key: "coin",
         },
     },
     balancePadding: 15,
@@ -59,25 +60,19 @@
         manage: "debug-demo-inventory",
     },
     confirm: {
-        detailView: true, // true === smaller image and more text. false === large image only.
+        detailView: true,
         prompt: {
             shop: { legal: "Purchase this item?", illegal: "You can't afford this." },
             manage: { legal: "Do you want to \nequip this item?", illegal: "You've already \nequipped this." },
-            // styles: {},
         },
-        // title: { styles: {} }, // optionally configure styles on item text
         detail: { styles: { color: "#2b2", fontStyle: "italic" } },
-        // description: { styles: {} },
-        // price: { styles: {} },
     },
     menu: {
-        buttonsRight: true, // set as false to X-flip the menu layout
+        buttonsRight: true,
     },
     columns: 1,
     assetKeys: {
-        // background: "background", // if a string is passed, that asset is used for all panes
         background: {
-            // menu: "", // pass empty string, or omit the key entirely, for a transparent BG
             shop: "background",
             manage: "background",
             confirm: "halfViewBackground",
@@ -95,14 +90,14 @@
                 type: "image",
                 name: "background",
                 assetKey: "itemBackground",
-                isDynamic: false, // asset key is the value of assetKey
+                isDynamic: false,
             },
             {
                 type: "image",
                 name: "itemIcon",
                 assetKey: "icon",
-                isDynamic: true, // asset key is item[assetKey]
-                position: { align: "left", offsetX: 35, offsetY: 0 }, // x offsets are from an edge, y offsets are from the centre
+                isDynamic: true,
+                position: { align: "left", offsetX: 35, offsetY: 0 },
                 size: 76,
             },
             {

--- a/debug/examples/shop.json5
+++ b/debug/examples/shop.json5
@@ -24,7 +24,7 @@
             xOffset: 0,
             yOffset: 0,
             styles: {
-                // modifies styleDefaults
+                // any text config can include styles, which modifies styleDefaults
                 fontSize: "30px",
             },
         },
@@ -104,7 +104,7 @@
                 value: "title",
                 isDynamic: true,
                 position: { align: "left", offsetX: 80, offsetY: -18 },
-                font: { fontFamily: "ReithSans", resolution: 5, fontSize: 18 }, // update these to conform
+                styles: { fontSize: 18 },
             },
             {
                 type: "text",
@@ -112,7 +112,7 @@
                 value: "description",
                 isDynamic: true,
                 position: { align: "left", offsetX: 80, offsetY: 4 },
-                font: { fontFamily: "ReithSans", resolution: 5, fontSize: 12 },
+                styles: { fontSize: 12 },
             },
         ],
         options: {
@@ -123,7 +123,7 @@
                     value: "price",
                     isDynamic: true,
                     position: { align: "right", offsetX: -44, offsetY: -10 },
-                    font: { fontFamily: "ReithSans", resolution: 5, fontSize: 14 },
+                    styles: { fontSize: 14 },
                     activeStates: ["cta"],
                 },
                 {
@@ -140,7 +140,6 @@
                     value: "Owned",
                     isDynamic: false,
                     position: { align: "right", offsetX: -76, offsetY: -10 },
-                    font: { fontFamily: "ReithSans", resolution: 5 },
                     activeStates: ["actioned"],
                 },
             ],
@@ -151,7 +150,6 @@
                     value: "Equip",
                     isDynamic: false,
                     position: { align: "right", offsetX: -76, offsetY: -10 },
-                    font: { fontFamily: "ReithSans", resolution: 5 },
                     activeStates: ["cta"],
                 },
                 {
@@ -160,7 +158,6 @@
                     value: "Equipped",
                     isDynamic: false,
                     position: { align: "right", offsetX: -88, offsetY: -10 },
-                    font: { fontFamily: "ReithSans", resolution: 5 },
                     activeStates: ["actioned"],
                 },
             ],

--- a/debug/examples/shop.json5
+++ b/debug/examples/shop.json5
@@ -142,7 +142,6 @@
                     isDynamic: false,
                     position: { align: "right", offsetX: -76, offsetY: -10 },
                     styles: { fontSize: 18 },
-
                     activeStates: ["actioned"],
                 },
             ],

--- a/debug/examples/shop.json5
+++ b/debug/examples/shop.json5
@@ -4,6 +4,13 @@
     background: {
         items: [{ key: "shop.magicShop", x: 0, y: 0 }],
     },
+    styleDefaults: {
+        // menu button text uses styleDefaults
+        fontFamily: "ReithSans",
+        fontSize: "24px",
+        resolution: 5,
+        align: "center",
+    },
     titles: [
         {
             type: "image",
@@ -17,8 +24,8 @@
             xOffset: 0,
             yOffset: 0,
             styles: {
-                fontSize: "24px",
-                resolution: 4,
+                // modifies styleDefaults
+                fontSize: "30px",
             },
         },
     ],
@@ -55,12 +62,6 @@
             manage: { legal: "Do you want to \nequip this item?", illegal: "You've already \nequipped this." },
         },
         // needs updating with styling objects
-    },
-    styleDefaults: {
-        fontFamily: "ReithSans",
-        fontSize: "24px",
-        resolution: 5,
-        align: "center",
     },
     menu: {
         buttonsRight: true, // set as false to X-flip the menu layout

--- a/debug/examples/shop.json5
+++ b/debug/examples/shop.json5
@@ -39,6 +39,7 @@
         value: {
             type: "text",
             key: "coin", // the id of the currency item, which must exist in the inventory collection
+            // styles: {},
         },
     },
     balancePadding: 15,

--- a/debug/examples/shop.json5
+++ b/debug/examples/shop.json5
@@ -35,7 +35,6 @@
         value: {
             type: "text",
             key: "coin", // the id of the currency item, which must exist in the inventory collection
-            styles: {},
         },
     },
     balancePadding: 15,
@@ -55,6 +54,7 @@
             shop: { legal: "Purchase this item?", illegal: "You can't afford this." },
             manage: { legal: "Do you want to \nequip this item?", illegal: "You've already \nequipped this." },
         },
+        // needs updating with styling objects
     },
     styleDefaults: {
         fontFamily: "ReithSans",
@@ -103,7 +103,7 @@
                 value: "title",
                 isDynamic: true,
                 position: { align: "left", offsetX: 80, offsetY: -18 },
-                font: { fontFamily: "ReithSans", resolution: 5, fontSize: 18 },
+                font: { fontFamily: "ReithSans", resolution: 5, fontSize: 18 }, // update these to conform
             },
             {
                 type: "text",

--- a/debug/examples/shop.json5
+++ b/debug/examples/shop.json5
@@ -5,10 +5,10 @@
         items: [{ key: "shop.magicShop", x: 0, y: 0 }],
     },
     styleDefaults: {
-        // menu button text uses styleDefaults
+        // menu button text uses styleDefaults, everything else can be modified.
         fontFamily: "ReithSans",
         fontSize: "24px",
-        resolution: 5,
+        resolution: 10,
         align: "center",
     },
     titles: [
@@ -23,10 +23,7 @@
             value: "Shop",
             xOffset: 0,
             yOffset: 0,
-            styles: {
-                // any text config can include styles, which modifies styleDefaults
-                fontSize: "30px",
-            },
+            styles: { fontSize: 30 },
         },
     ],
     titlePadding: 20,
@@ -57,11 +54,15 @@
     },
     confirm: {
         detailView: true, // true === smaller image and more text. false === large image only.
-        prompts: {
+        prompt: {
             shop: { legal: "Purchase this item?", illegal: "You can't afford this." },
             manage: { legal: "Do you want to \nequip this item?", illegal: "You've already \nequipped this." },
+            // styles: {},
         },
-        // needs updating with styling objects
+        // title: { styles: {} }, // optionally configure styles on item text
+        detail: { styles: { color: "#2b2", fontStyle: "italic" } },
+        // description: { styles: {} },
+        // price: { styles: {} },
     },
     menu: {
         buttonsRight: true, // set as false to X-flip the menu layout
@@ -140,6 +141,8 @@
                     value: "Owned",
                     isDynamic: false,
                     position: { align: "right", offsetX: -76, offsetY: -10 },
+                    styles: { fontSize: 18 },
+
                     activeStates: ["actioned"],
                 },
             ],
@@ -150,6 +153,7 @@
                     value: "Equip",
                     isDynamic: false,
                     position: { align: "right", offsetX: -76, offsetY: -10 },
+                    styles: { fontSize: 18 },
                     activeStates: ["cta"],
                 },
                 {
@@ -157,7 +161,8 @@
                     name: "equipped",
                     value: "Equipped",
                     isDynamic: false,
-                    position: { align: "right", offsetX: -88, offsetY: -10 },
+                    position: { align: "right", offsetX: -96, offsetY: -10 },
+                    styles: { fontSize: 18 },
                     activeStates: ["actioned"],
                 },
             ],

--- a/src/components/shop/balance-ui.js
+++ b/src/components/shop/balance-ui.js
@@ -6,15 +6,9 @@
  * @license Apache-2.0
  */
 
-import { getXPos, getYPos, getScaleFactor, getSafeArea } from "./shop-layout.js";
+import { getXPos, getYPos, getScaleFactor, getSafeArea, textStyle } from "./shop-layout.js";
 import { getMetrics } from "../../core/scaler.js";
 import { collections } from "../../core/collections.js";
-
-const styleDefaults = {
-    fontFamily: "ReithSans",
-    fontSize: "24px",
-    resolution: 4,
-};
 
 const makeElement = makerFns => conf => makerFns[conf.type](conf).setOrigin(0.5);
 
@@ -24,11 +18,9 @@ const getBalanceValue = scene =>
 export const createBalance = scene => {
     const safeArea = getSafeArea(scene.layout);
     const metrics = getMetrics();
+    const { styleDefaults } = scene.config;
     const image = conf => scene.add.image(0, 0, `${scene.assetPrefix}.${conf.key}`);
-    const text = conf => {
-        const textStyle = { ...styleDefaults, ...conf.styles };
-        return scene.add.text(0, 0, getBalanceValue(scene), textStyle);
-    };
+    const text = conf => scene.add.text(0, 0, getBalanceValue(scene), textStyle(styleDefaults, conf));
     const container = scene.add.container();
     const configs = scene.config.balance;
     const padding = scene.config.balancePadding;

--- a/src/components/shop/confirm.js
+++ b/src/components/shop/confirm.js
@@ -37,7 +37,7 @@ export const createConfirm = scene => {
     container.elems = {
         background: [createRect(scene, innerBounds, 0x0000ff), createPaneBackground(scene, bounds, "confirm")],
         prompt: scene.add
-            .text(getX(innerBounds.x, config), promptY(bounds), config.confirm.prompts.shop, styleDefaults)
+            .text(getX(innerBounds.x, config), promptY(bounds), config.confirm.prompts.shop, styleDefaults) // all needs updating to merge in changes to the defaults
             .setOrigin(0.5),
         price: scene.add.text(getX(innerBounds.x + 28, config), currencyY(bounds), "PH", styleDefaults).setOrigin(0.5),
         priceIcon: scene.add.image(

--- a/src/components/shop/confirm.js
+++ b/src/components/shop/confirm.js
@@ -12,6 +12,7 @@ import {
     createRect,
     getSafeArea,
     createPaneBackground,
+    textStyle,
 } from "./shop-layout.js";
 import { createConfirmButtons } from "./menu-buttons.js";
 import { doTransaction } from "./transact.js";
@@ -37,9 +38,21 @@ export const createConfirm = scene => {
     container.elems = {
         background: [createRect(scene, innerBounds, 0x0000ff), createPaneBackground(scene, bounds, "confirm")],
         prompt: scene.add
-            .text(getX(innerBounds.x, config), promptY(bounds), config.confirm.prompts.shop, styleDefaults) // all needs updating to merge in changes to the defaults
+            .text(
+                getX(innerBounds.x, config),
+                promptY(bounds),
+                config.confirm.prompt.shop,
+                textStyle(styleDefaults, config.confirm.prompt),
+            )
             .setOrigin(0.5),
-        price: scene.add.text(getX(innerBounds.x + 28, config), currencyY(bounds), "PH", styleDefaults).setOrigin(0.5),
+        price: scene.add
+            .text(
+                getX(innerBounds.x + 28, config),
+                currencyY(bounds),
+                "PH",
+                textStyle(styleDefaults, config.confirm.price),
+            )
+            .setOrigin(0.5),
         priceIcon: scene.add.image(
             getX(innerBounds.x - 20, config),
             currencyY(bounds),
@@ -96,8 +109,8 @@ const update = (scene, container) => (item, title) => {
 
 const setLegal = container => (title, isLegal) => {
     const prompt = isLegal
-        ? container.config.confirm.prompts[title].legal
-        : container.config.confirm.prompts[title].illegal;
+        ? container.config.confirm.prompt[title].legal
+        : container.config.confirm.prompt[title].illegal;
     container.elems.prompt.setText(prompt);
     container.buttons[0].setLegal(isLegal);
 };
@@ -129,25 +142,32 @@ const itemImageView = (scene, item, config, bounds) => {
 
 const itemDetailView = (scene, item, config, bounds) => {
     const x = imageX(config, bounds);
+    const { styleDefaults } = config;
+    const { title, detail, description } = config.confirm;
     const itemImage = scene.add.image(x, imageY(bounds), assetKey(item));
     itemImage.setScale(bounds.height / 3 / itemImage.height);
-    const itemTitle = scene.add.text(x, 0, getItemDetail(item), config.styleDefaults).setOrigin(0.5);
-    const itemBlurb = scene.add.text(x, blurbY(bounds), getItemBlurb(item), config.styleDefaults, 0).setOrigin(0.5);
-    return [itemImage, itemTitle, itemBlurb];
+    const itemTitle = scene.add.text(x, 0, getItemTitle(item), textStyle(styleDefaults, title)).setOrigin(0.5);
+    const itemDetail = scene.add
+        .text(x, detailY(bounds), getItemDetail(item), textStyle(styleDefaults, detail))
+        .setOrigin(0.5);
+    const itemBlurb = scene.add
+        .text(x, blurbY(bounds), getItemBlurb(item), textStyle(styleDefaults, description), 0)
+        .setOrigin(0.5);
+    return [itemImage, itemTitle, itemDetail, itemBlurb];
 };
 
 const getItemState = (container, item, title) =>
     collections.get(getCollectionsKey(container, title)).get(item.id).state;
 const getCollectionsKey = (container, title) => container.config.paneCollections[title];
-const getItemDetail = item => getItemTitle(item) + "\n" + getItemDescription(item);
 const getItemTitle = item => (item ? item.title : "Item Default Title");
-const getItemDescription = item => (item ? item.description : "Item Default Description");
+const getItemDetail = item => (item ? item.description : "");
 const getItemBlurb = item => (item ? item.longDescription : "");
 const assetKey = item => (item ? item.icon : "shop.itemIcon");
 const imageY = bounds => -bounds.height / 4;
 const getX = (x, config) => (config.menu.buttonsRight ? x : -x);
 const promptY = outerBounds => -outerBounds.height * (3 / 8);
 const currencyY = outerBounds => -outerBounds.height / 4;
+const detailY = bounds => bounds.height / 12;
 const blurbY = bounds => bounds.height / 4;
 const getOffsetBounds = (outerBounds, innerBounds) => ({
     ...innerBounds,

--- a/src/components/shop/menu-buttons.js
+++ b/src/components/shop/menu-buttons.js
@@ -81,4 +81,4 @@ const resizeButton = container => (button, idx) => {
 export const resizeGelButtons = container => container.buttons.forEach(resizeButton(container));
 
 const setButtonOverlays = (scene, button, title) =>
-    button.overlays.set("caption", scene.add.text(0, 0, title, { ...styleDefaults }).setOrigin(0.5));
+    button.overlays.set("caption", scene.add.text(0, 0, title, styleDefaults).setOrigin(0.5));

--- a/src/components/shop/shop-layout.js
+++ b/src/components/shop/shop-layout.js
@@ -115,4 +115,14 @@ export const getPaneBackgroundKey = (scene, pane) => {
     return background[pane] ? `${assetPrefix}.${background[pane]}` : null;
 };
 
-export const textStyle = (styleDefaults, config) => (config ? { ...styleDefaults, ...config.styles } : styleDefaults);
+const fallbackStyle = {
+    fontFamily: "ReithSans",
+    fontSize: "24px",
+    resolution: 10,
+    align: "center",
+};
+
+export const textStyle = (styleDefaults, config) => {
+    const defaults = styleDefaults ? styleDefaults : fallbackStyle;
+    return config ? { ...defaults, ...config.styles } : defaults;
+};

--- a/src/components/shop/shop-layout.js
+++ b/src/components/shop/shop-layout.js
@@ -115,6 +115,4 @@ export const getPaneBackgroundKey = (scene, pane) => {
     return background[pane] ? `${assetPrefix}.${background[pane]}` : null;
 };
 
-export const textStyle = (styleDefaults, config) => {
-    return config.styles ? { ...styleDefaults, ...config.styles } : styleDefaults;
-};
+export const textStyle = (styleDefaults, config) => ({ ...styleDefaults, ...config.styles });

--- a/src/components/shop/shop-layout.js
+++ b/src/components/shop/shop-layout.js
@@ -115,4 +115,4 @@ export const getPaneBackgroundKey = (scene, pane) => {
     return background[pane] ? `${assetPrefix}.${background[pane]}` : null;
 };
 
-export const textStyle = (styleDefaults, config) => ({ ...styleDefaults, ...config.styles });
+export const textStyle = (styleDefaults, config) => (config ? { ...styleDefaults, ...config.styles } : styleDefaults);

--- a/src/components/shop/shop-layout.js
+++ b/src/components/shop/shop-layout.js
@@ -114,3 +114,7 @@ export const getPaneBackgroundKey = (scene, pane) => {
 
     return background[pane] ? `${assetPrefix}.${background[pane]}` : null;
 };
+
+export const textStyle = (styleDefaults, config) => {
+    return config.styles ? { ...styleDefaults, ...config.styles } : styleDefaults;
+};

--- a/src/components/shop/shop-titles.js
+++ b/src/components/shop/shop-titles.js
@@ -13,7 +13,7 @@ export const createTitle = scene => {
     const safeArea = getSafeArea(scene.layout);
     const metrics = getMetrics();
     const titleContainer = scene.add.container();
-    titleContainer.add(createTitles(scene)); // do we need to look at select/titles in order to shape the config object?
+    titleContainer.add(createTitles(scene));
 
     titleContainer.setScale(
         getScaleFactor({

--- a/src/components/shop/shop-titles.js
+++ b/src/components/shop/shop-titles.js
@@ -13,7 +13,7 @@ export const createTitle = scene => {
     const safeArea = getSafeArea(scene.layout);
     const metrics = getMetrics();
     const titleContainer = scene.add.container();
-    titleContainer.add(createTitles(scene));
+    titleContainer.add(createTitles(scene)); // do we need to look at select/titles in order to shape the config object?
 
     titleContainer.setScale(
         getScaleFactor({

--- a/src/core/layout/scrollable-list/button-overlays.js
+++ b/src/core/layout/scrollable-list/button-overlays.js
@@ -26,7 +26,7 @@ const setImageOverlay = ({ gelButton, overlay, offset }) => {
 const setTextOverlay = ({ gelButton, overlay, offset }) => {
     const { scene, item } = gelButton;
     const textContent = overlay.isDynamic ? item[overlay.value].toString() : overlay.value.toString();
-    gelButton.overlays.set(overlay.name, scene.add.text(offset.x, offset.y, textContent, overlay.font));
+    gelButton.overlays.set(overlay.name, scene.add.text(offset.x, offset.y, textContent, overlay.font)); // needs to account for styling in same way as others
 };
 
 const getOffset = (position, gelButton) => {

--- a/src/core/layout/scrollable-list/button-overlays.js
+++ b/src/core/layout/scrollable-list/button-overlays.js
@@ -5,28 +5,33 @@
  * @license Apache-2.0 Apache-2.0
  */
 import fp from "../../../../lib/lodash/fp/fp.js";
+import { textStyle } from "../../../components/shop/shop-layout.js";
 
 export const overlays1Wide = (gelButton, configs) => {
-    configs.forEach(overlay => {
-        const offset = getOffset(overlay.position, gelButton);
-        addOverlay({ gelButton, overlay, offset });
+    configs.forEach(config => {
+        const offset = getOffset(config.position, gelButton);
+        addOverlay({ gelButton, config, offset });
     });
     return gelButton;
 };
 
-const setImageOverlay = ({ gelButton, overlay, offset }) => {
+const setImageOverlay = ({ gelButton, config, offset }) => {
     const { scene, item } = gelButton;
     const { assetPrefix } = scene.config;
-    const key = overlay.isDynamic ? `${item[overlay.assetKey]}` : `${assetPrefix}.${overlay.assetKey}`;
+    const key = config.isDynamic ? `${item[config.assetKey]}` : `${assetPrefix}.${config.assetKey}`;
     const image = scene.add.image(offset.x, offset.y, key);
-    overlay.size && image.setScale(overlay.size / image.width);
-    gelButton.overlays.set(overlay.name, image);
+    config.size && image.setScale(config.size / image.width);
+    gelButton.overlays.set(config.name, image);
 };
 
-const setTextOverlay = ({ gelButton, overlay, offset }) => {
+const setTextOverlay = ({ gelButton, config, offset }) => {
     const { scene, item } = gelButton;
-    const textContent = overlay.isDynamic ? item[overlay.value].toString() : overlay.value.toString();
-    gelButton.overlays.set(overlay.name, scene.add.text(offset.x, offset.y, textContent, overlay.font)); // needs to account for styling in same way as others
+    const { styleDefaults } = scene.config;
+    const textContent = config.isDynamic ? item[config.value].toString() : config.value.toString();
+    gelButton.overlays.set(
+        config.name,
+        scene.add.text(offset.x, offset.y, textContent, textStyle(styleDefaults, config)),
+    ); // needs to account for styling in same way as others
 };
 
 const getOffset = (position, gelButton) => {
@@ -36,6 +41,6 @@ const getOffset = (position, gelButton) => {
 };
 
 const addOverlay = fp.cond([
-    [args => args.overlay.type === "image", setImageOverlay],
-    [args => args.overlay.type === "text", setTextOverlay],
+    [args => args.config.type === "image", setImageOverlay],
+    [args => args.config.type === "text", setTextOverlay],
 ]);

--- a/src/core/layout/scrollable-list/button-overlays.js
+++ b/src/core/layout/scrollable-list/button-overlays.js
@@ -31,7 +31,7 @@ const setTextOverlay = ({ gelButton, config, offset }) => {
     gelButton.overlays.set(
         config.name,
         scene.add.text(offset.x, offset.y, textContent, textStyle(styleDefaults, config)),
-    ); // needs to account for styling in same way as others
+    );
 };
 
 const getOffset = (position, gelButton) => {

--- a/test/components/shop/balance-ui.test.js
+++ b/test/components/shop/balance-ui.test.js
@@ -57,12 +57,12 @@ describe("createBalance()", () => {
                 value: {
                     type: "text",
                     key: "someId",
-                    styles: { foo: "bar" },
                 },
             },
             balancePadding: 6,
             listPadding: { x: 1 },
             paneCollections: { manage: "inventory" },
+            styleDefaults: { some: "default" },
         },
         layout: {
             getSafeArea: jest.fn(() => mockSafeArea),
@@ -90,14 +90,8 @@ describe("createBalance()", () => {
         expect(mockScene.add.image).toHaveBeenCalledWith(0, 0, "shop.balanceBackground");
         expect(mockScene.add.image).toHaveBeenCalledWith(0, 0, "shop.balanceIcon");
     });
-    test("adds a text element, merging the provided styles with defaults", () => {
-        const expectedStyles = {
-            fontFamily: "ReithSans",
-            fontSize: "24px",
-            resolution: 4,
-            foo: "bar",
-        };
-        expect(mockScene.add.text.mock.calls[0][3]).toStrictEqual(expectedStyles);
+    test("adds a text element with the value of the balance", () => {
+        expect(mockScene.add.text.mock.calls[0][2]).toBe(100);
     });
     test("uses the quantity of the currency item from inventory as its value", () => {
         expect(collections.get).toHaveBeenCalledWith("inventory");

--- a/test/components/shop/confirm.test.js
+++ b/test/components/shop/confirm.test.js
@@ -21,7 +21,7 @@ describe("createConfirm()", () => {
     let mockConfig = {
         menu: { buttonsRight: true },
         confirm: {
-            prompts: {
+            prompt: {
                 shop: { legal: "legalBuyPrompt", illegal: "illegalBuyPrompt" },
                 manage: { legal: "legalEquipPrompt", illegal: "illegalEquipPrompt" },
             },
@@ -59,6 +59,7 @@ describe("createConfirm()", () => {
     layout.resize = jest.fn().mockReturnValue(resizeFn);
     layout.createRect = jest.fn().mockReturnValue(mockRect);
     layout.getInnerRectBounds = jest.fn().mockReturnValue({ x: 0, y: 0, width: 100, height: 100 });
+    layout.textStyle = jest.fn().mockReturnValue({ some: "textStyle" });
     let mockDoTransactionFn = jest.fn().mockReturnValueOnce(37).mockReturnValue(undefined);
     transact.doTransaction = jest.fn().mockReturnValue(mockDoTransactionFn);
     const mockCollection = { get: jest.fn().mockReturnValue({ state: "foo" }) };
@@ -106,7 +107,7 @@ describe("createConfirm()", () => {
         jest.clearAllMocks();
         mockScene.config = { ...mockConfig, menu: { buttonsRight: false } };
         createConfirm(mockScene);
-        expect(mockScene.add.text).toHaveBeenCalledWith(-28, -25, "PH", {});
+        expect(mockScene.add.text).toHaveBeenCalledWith(-28, -25, "PH", { some: "textStyle" });
     });
     test("that is displayed with an appropriate Y offset", () => {
         expect(mockContainer.setY).toHaveBeenCalledWith(55);
@@ -124,9 +125,9 @@ describe("createConfirm()", () => {
             confirmPane = createConfirm(mockScene);
         });
         test("adds extra placeholder text objects", () => {
-            expect(mockScene.add.text).toHaveBeenCalledTimes(4);
+            expect(mockScene.add.text).toHaveBeenCalledTimes(5);
             const containerContents = mockContainer.add.mock.calls[0][0];
-            expect(containerContents.slice(-3)).toStrictEqual([mockImage, mockText, mockText]);
+            expect(containerContents.slice(-4)).toStrictEqual([mockImage, mockText, mockText, mockText]);
         });
     });
 

--- a/test/components/shop/shop-layout.test.js
+++ b/test/components/shop/shop-layout.test.js
@@ -223,4 +223,20 @@ describe("shop element scaling functions", () => {
             expect(mockScene.add.rectangle).toHaveBeenCalled();
         });
     });
+
+    describe("textStyle()", () => {
+        const defaultStyle = { some: "default", foo: "bar" };
+        let elementConfig;
+
+        test("merges default style with style from element config", () => {
+            elementConfig = { some: "config", styles: { foo: "baz" } };
+            const expectedStyle = { some: "default", foo: "baz" };
+            expect(shopLayout.textStyle(defaultStyle, elementConfig)).toStrictEqual(expectedStyle);
+        });
+        test("if there's no element config, returns the default style", () => {
+            elementConfig = { some: "config" };
+            const expectedStyle = defaultStyle;
+            expect(shopLayout.textStyle(defaultStyle, elementConfig)).toBe(expectedStyle);
+        });
+    });
 });

--- a/test/components/shop/shop-layout.test.js
+++ b/test/components/shop/shop-layout.test.js
@@ -234,7 +234,7 @@ describe("shop element scaling functions", () => {
             expect(shopLayout.textStyle(defaultStyle, elementConfig)).toStrictEqual(expectedStyle);
         });
         test("if there's no element config, returns the default style", () => {
-            elementConfig = { some: "config" };
+            elementConfig = undefined;
             const expectedStyle = defaultStyle;
             expect(shopLayout.textStyle(defaultStyle, elementConfig)).toStrictEqual(expectedStyle);
         });

--- a/test/components/shop/shop-layout.test.js
+++ b/test/components/shop/shop-layout.test.js
@@ -236,7 +236,7 @@ describe("shop element scaling functions", () => {
         test("if there's no element config, returns the default style", () => {
             elementConfig = { some: "config" };
             const expectedStyle = defaultStyle;
-            expect(shopLayout.textStyle(defaultStyle, elementConfig)).toBe(expectedStyle);
+            expect(shopLayout.textStyle(defaultStyle, elementConfig)).toStrictEqual(expectedStyle);
         });
     });
 });

--- a/test/components/shop/shop-layout.test.js
+++ b/test/components/shop/shop-layout.test.js
@@ -238,5 +238,14 @@ describe("shop element scaling functions", () => {
             const expectedStyle = defaultStyle;
             expect(shopLayout.textStyle(defaultStyle, elementConfig)).toStrictEqual(expectedStyle);
         });
+        test("if there's no default style, use a fallback style", () => {
+            const fallbackStyle = {
+                fontFamily: "ReithSans",
+                fontSize: "24px",
+                resolution: 10,
+                align: "center",
+            };
+            expect(shopLayout.textStyle(undefined, undefined)).toStrictEqual(fallbackStyle);
+        });
     });
 });

--- a/test/core/layout/scrollable-list/button-overlays.test.js
+++ b/test/core/layout/scrollable-list/button-overlays.test.js
@@ -5,6 +5,7 @@
  * @license Apache-2.0 Apache-2.0
  */
 import { overlays1Wide } from "../../../../src/core/layout/scrollable-list/button-overlays.js";
+import * as shopLayout from "../../../../src/components/shop/shop-layout.js";
 
 const mockImage = { setScale: jest.fn(), width: 100 };
 const mockScene = {
@@ -15,6 +16,7 @@ const mockScene = {
     config: {
         assetPrefix: "test",
     },
+    styleDefaults: { some: "default" },
 };
 
 const mockItem = {
@@ -35,6 +37,8 @@ const mockGelButton = {
 
 let mockOverlay;
 let mockConfig;
+
+shopLayout.textStyle = jest.fn().mockReturnValue({ foo: "bar" });
 
 describe("Button overlays", () => {
     afterEach(() => jest.clearAllMocks());
@@ -74,19 +78,12 @@ describe("Button overlays", () => {
                 expect(mockImage.setScale).toHaveBeenCalledWith(0.5);
             });
 
-            test("adds a text to the scene and the button if overlay is of type text", () => {
+            test("adds a text to the scene and the button if overlay is of type text, merging default styles with any provided.", () => {
                 mockOverlay = { ...mockOverlay, type: "text", value: "someText" };
                 mockConfig.overlay.items.push(mockOverlay);
                 overlays1Wide(mockGelButton, mockConfig.overlay.items);
-                expect(mockScene.add.text).toHaveBeenCalledWith(0, 0, "someText", undefined);
-            });
-
-            test("text elements pass font information from the overlay if present", () => {
-                mockOverlay = { ...mockOverlay, type: "text", value: "someText", font: { foo: "bar" } };
-                mockConfig.overlay.items.push(mockOverlay);
-                const expectedFont = mockOverlay.font;
-                overlays1Wide(mockGelButton, mockConfig.overlay.items);
-                expect(mockScene.add.text).toHaveBeenCalledWith(0, 0, "someText", expectedFont);
+                expect(mockScene.add.text).toHaveBeenCalledWith(0, 0, "someText", { foo: "bar" });
+                expect(shopLayout.textStyle).toHaveBeenCalled();
             });
         });
 
@@ -111,7 +108,7 @@ describe("Button overlays", () => {
                 mockConfig.overlay.items.push(mockOverlay);
                 overlays1Wide(mockGelButton, mockConfig.overlay.items);
                 const expectedValue = "42";
-                expect(mockScene.add.text).toHaveBeenCalledWith(0, 0, expectedValue, undefined);
+                expect(mockScene.add.text).toHaveBeenCalledWith(0, 0, expectedValue, { foo: "bar" });
             });
         });
 


### PR DESCRIPTION
- DRY style merging with new fn on shop-layout (mostly, to force consistency)
- Update scene.add.text() calls to use new styling fn
- Modify confirm.js to create three text fields in item detail view, rather than 2
- Update shop config to reflect & exemplify changes
- Strip explanatory comments from the demo game shop config, since they were duplicates.