### PR TITLE
[CGPROD-3012] guard vs race condition on getTopmostSizer 

### DIFF
--- a/src/core/layout/scrollable-list/scrollable-list-handlers.js
+++ b/src/core/layout/scrollable-list/scrollable-list-handlers.js
@@ -9,10 +9,13 @@
 import fp from "../../../../lib/lodash/fp/fp.js";
 
 const handleClickIfVisible = (gelButton, scene, handler) => () => {
+    if (!gelButton.rexContainer.parent) return;
+
     if (isA11yClick(scene)) {
         handler(gelButton);
         return;
     }
+
     const panel = gelButton.rexContainer.parent.getTopmostSizer();
     const safeArea = scene.layout.getSafeArea({}, false);
     const height = scene.scale.displaySize.height;

--- a/test/core/layout/scrollable-list/scrollable-list-handlers.test.js
+++ b/test/core/layout/scrollable-list/scrollable-list-handlers.test.js
@@ -56,9 +56,14 @@ describe("Scrollable List handlers", () => {
             handler();
             expect(mockClickHandler).toHaveBeenCalled();
         });
-
         test("returns a fn that does not call clickHandler if click is outside the panel", () => {
             mockScene.input.y = 0;
+            const handler = handlers.handleClickIfVisible(mockGelButton, mockScene, mockClickHandler);
+            handler();
+            expect(mockClickHandler).not.toHaveBeenCalled();
+        });
+        test("if the panel does not exist yet, guard vs race condition", () => {
+            mockGelButton.rexContainer.parent = undefined;
             const handler = handlers.handleClickIfVisible(mockGelButton, mockScene, mockClickHandler);
             handler();
             expect(mockClickHandler).not.toHaveBeenCalled();


### PR DESCRIPTION
- Like other buttons in genie, scrollable list buttons are GEL buttons, and are a synthesis of DOM elements and interactive Phaser elements
- Since the scrollable list builds inner elements first, GEL buttons may be live in the DOM before the scrollable list has finished construction
- We were seeing rare, hard to reproduce crashes on calls to `gelButton.rexContainer.parent.getTopmostSizer()` which were _probably_ caused in this way
- Added a guard if `parent` (i.e. the scrollable list) does not yet exist, and a test to document
- This should be fine as any event hitting this time window ought to be happening before the list is visible to the user (i.e. we can assume it was not an intentional click.)