### PR TITLE
[CGPROD-3013] part deux- refine scroll wheel behaviour

### DIFF
--- a/src/core/layout/scrollable-list/scrollable-list-handlers.js
+++ b/src/core/layout/scrollable-list/scrollable-list-handlers.js
@@ -81,10 +81,13 @@ const getMaxOffset = panel => {
     return getItemsHeight(panel) - visibleWindowHeight;
 };
 
-/* eslint-disable-next-line no-unused-vars */
-const updatePanelOnWheel = panel => (pointer, elem, deltaX, deltaY, deltaZ, event) => {
+const updatePanelOnWheel = panel => (...args) => {
+    const event = args[5];
     event.stopPropagation();
+
     if (!panel.visible) return;
+
+    const pointer = args[0];
     const delta = pointer.deltaY * WHEEL_SCROLL_FACTOR;
     const t = Math.min(Math.max(0, panel.t + delta), 1);
     panel.setT(t);

--- a/src/core/layout/scrollable-list/scrollable-list-handlers.js
+++ b/src/core/layout/scrollable-list/scrollable-list-handlers.js
@@ -4,7 +4,6 @@
  * @author BBC Children's D+E
  * @license Apache-2.0 Apache-2.0
  */
-/* eslint-disable no-console */
 
 import fp from "../../../../lib/lodash/fp/fp.js";
 
@@ -82,9 +81,11 @@ const getMaxOffset = panel => {
     return getItemsHeight(panel) - visibleWindowHeight;
 };
 
-const updatePanelOnWheel = panel => e => {
-    if (!panel.visible || !panel.isInTouching()) return;
-    const delta = e.deltaY * WHEEL_SCROLL_FACTOR;
+/* eslint-disable-next-line no-unused-vars */
+const updatePanelOnWheel = panel => (pointer, elem, deltaX, deltaY, deltaZ, event) => {
+    event.stopPropagation();
+    if (!panel.visible) return;
+    const delta = pointer.deltaY * WHEEL_SCROLL_FACTOR;
     const t = Math.min(Math.max(0, panel.t + delta), 1);
     panel.setT(t);
 };

--- a/src/core/layout/scrollable-list/scrollable-list-handlers.js
+++ b/src/core/layout/scrollable-list/scrollable-list-handlers.js
@@ -7,8 +7,6 @@
 
 import fp from "../../../../lib/lodash/fp/fp.js";
 
-const WHEEL_SCROLL_FACTOR = 0.005;
-
 const handleClickIfVisible = (gelButton, scene, handler) => () => {
     if (!gelButton.rexContainer.parent) return;
 
@@ -78,7 +76,7 @@ const updateScrollPosition = (panel, offset) => {
 
 const getMaxOffset = panel => {
     const visibleWindowHeight = panel.minHeight - panel.space.top * 2;
-    return getItemsHeight(panel) - visibleWindowHeight;
+    return Math.max(getItemsHeight(panel) - visibleWindowHeight, 0);
 };
 
 const updatePanelOnWheel = panel => (...args) => {
@@ -87,10 +85,16 @@ const updatePanelOnWheel = panel => (...args) => {
 
     if (!panel.visible) return;
 
-    const pointer = args[0];
-    const delta = pointer.deltaY * WHEEL_SCROLL_FACTOR;
+    const { deltaY } = args[0];
+    const delta = deltaY * wheelScrollFactor(panel);
     const t = Math.min(Math.max(0, panel.t + delta), 1);
-    panel.setT(t);
+    panel.t !== t && panel.setT(t);
+};
+
+const wheelScrollFactor = panel => {
+    const maxOffset = getMaxOffset(panel);
+    if (maxOffset === 0) return maxOffset;
+    return 1 / maxOffset;
 };
 
 export { handleClickIfVisible, updatePanelOnFocus, updatePanelOnScroll, updatePanelOnWheel };

--- a/src/core/layout/scrollable-list/scrollable-list.js
+++ b/src/core/layout/scrollable-list/scrollable-list.js
@@ -128,11 +128,11 @@ const setupEvents = (scene, panel) => {
     panel.on("scroll", panel.updateOnScroll);
 
     const onMouseWheelListener = updatePanelOnWheel(panel);
-    scene.input.on("wheel", onMouseWheelListener);
+    scene.input.on("gameobjectwheel", onMouseWheelListener);
 
     scene.events.once("shutdown", () => {
         scene.scale.removeListener("resize", debouncedResize);
-        scene.input.removeListener("wheel", onMouseWheelListener);
+        scene.input.removeListener("gameobjectwheel", onMouseWheelListener);
     });
 
     panel.updateOnFocus = updatePanelOnFocus(panel);

--- a/test/core/layout/scrollable-list/scrollable-list-handlers.test.js
+++ b/test/core/layout/scrollable-list/scrollable-list-handlers.test.js
@@ -167,22 +167,24 @@ describe("Scrollable List handlers", () => {
     });
 
     describe("updatePanelOnWheel", () => {
-        test("is a curried fn that sets t (scroll position) on the panel if visible and touching the pointer", () => {
+        let mockEvent;
+        let args;
+        beforeEach(() => {
+            mockEvent = { stopPropagation: jest.fn() };
+            args = [{ deltaY: 1 }, undefined, undefined, undefined, undefined, mockEvent];
+        });
+        test("is a curried fn that sets t (scroll position) on the panel and stops propagation.", () => {
             const onWheelFn = handlers.updatePanelOnWheel(mockPanel);
-            onWheelFn({ deltaY: 1 });
+            onWheelFn(...args);
             expect(mockPanel.setT).toHaveBeenCalled();
+            expect(mockEvent.stopPropagation).toHaveBeenCalled();
         });
         test("does not set t if not visible", () => {
             mockPanel.visible = false;
             const onWheelFn = handlers.updatePanelOnWheel(mockPanel);
-            onWheelFn({ deltaY: 1 });
+            onWheelFn(...args);
             expect(mockPanel.setT).not.toHaveBeenCalled();
-        });
-        test("does not set t if not touching pointer", () => {
-            mockPanel.isInTouching = jest.fn().mockReturnValue(false);
-            const onWheelFn = handlers.updatePanelOnWheel(mockPanel);
-            onWheelFn({ deltaY: 1 });
-            expect(mockPanel.setT).not.toHaveBeenCalled();
+            expect(mockEvent.stopPropagation).toHaveBeenCalled();
         });
     });
 });

--- a/test/core/layout/scrollable-list/scrollable-list-handlers.test.js
+++ b/test/core/layout/scrollable-list/scrollable-list-handlers.test.js
@@ -186,5 +186,12 @@ describe("Scrollable List handlers", () => {
             expect(mockPanel.setT).not.toHaveBeenCalled();
             expect(mockEvent.stopPropagation).toHaveBeenCalled();
         });
+        test("does not set T if scrolling is not possible (i.e. list is shorter than pane)", () => {
+            mockPanel.minHeight = 200;
+            const onWheelFn = handlers.updatePanelOnWheel(mockPanel);
+            onWheelFn(...args);
+            expect(mockPanel.setT).not.toHaveBeenCalled();
+            expect(mockEvent.stopPropagation).toHaveBeenCalled();
+        });
     });
 });

--- a/test/core/layout/scrollable-list/scrollable-list.test.js
+++ b/test/core/layout/scrollable-list/scrollable-list.test.js
@@ -284,7 +284,7 @@ describe("Scrollable List", () => {
                 expect(onFocusSpy).toHaveBeenCalled();
             });
             test("adds a mousewheel listener to pick up mousewheel and touch scroll events", () => {
-                expect(mockScene.input.on.mock.calls[0][0]).toBe("wheel");
+                expect(mockScene.input.on.mock.calls[0][0]).toBe("gameobjectwheel");
                 mockScene.input.on.mock.calls[0][1]();
                 expect(onWheelSpy).toHaveBeenCalled();
             });


### PR DESCRIPTION
- modified mousewheel handler to sub to the more specific and useful `gameobjectwheel` event
- prevent propagation, fixing full-screen 'bounce' effect on some browsers
- removed hard-coded `WHEEL_SCROLL_FACTOR` as it was giving us very variable results dependent on framerate and client
- added `wheelScrollFactor` fn that returns a scroll factor that's inversely proportional to the size of the list - this should give us a more consistent scroll rate.
- clamped `getMaxOffset` to a zero lower limit (so a list that's smaller than the pane has a zero max offset.)
- guard against setting t on the list when it hasn't changed (for efficiency- setting t kicks off a bunch of other code.)