### PR TITLE
[CGPROD-2949] consumables in inventory

### DIFF
--- a/src/components/shop/confirm.js
+++ b/src/components/shop/confirm.js
@@ -51,7 +51,7 @@ export const createConfirm = scene => {
 
     container.setVisible = setVisible(container);
     container.resize = resize(container);
-    container.update = update(container);
+    container.updateItem = updateItem(container);
     container.prepTransaction = prepTransaction(scene, container);
     container.doTransaction = doTransaction(scene);
     container.setBalance = bal => balance.setText(bal);
@@ -83,7 +83,7 @@ const isTransactionLegal = (container, item, title) => {
 
 const confirm = container => container.transaction && container.doTransaction(container.transaction);
 
-const update = container => (item, title) => {
+const updateItem = container => (item, title) => {
     const isLegal = isTransactionLegal(container, item, title);
     container.elems.priceIcon.setVisible(title === "shop");
     container.elems.price.setText(title === "shop" ? item.price : "");
@@ -135,7 +135,7 @@ const populate = container =>
 
 const prepTransaction = (scene, container) => (item, title) => {
     scene.stack("confirm");
-    container.update(item, title); // change name of method
+    container.updateItem(item, title);
 };
 
 const itemView = (scene, item, config, bounds) =>

--- a/src/core/layout/scrollable-list/scrollable-list-buttons.js
+++ b/src/core/layout/scrollable-list/scrollable-list-buttons.js
@@ -8,7 +8,7 @@ import { overlays1Wide } from "./button-overlays.js";
 import { collections } from "../../collections.js";
 import fp from "../../../../lib/lodash/fp/fp.js";
 
-const STATES = ["cta", "actioned", "inStock"];
+// const STATES = ["cta", "actioned", "inStock"];
 
 const createGelButton = (scene, item, title, state) => {
     const id = `scroll_button_${item.id}_${title}`;

--- a/test/components/shop/transact.test.js
+++ b/test/components/shop/transact.test.js
@@ -7,7 +7,6 @@
 
 import * as transact from "../../../src/components/shop/transact.js";
 import { collections } from "../../../src/core/collections.js";
-import { catchClause } from "@babel/types";
 
 describe("doTransaction", () => {
     let mockTx;


### PR DESCRIPTION
- Refactor overlay config; remove `isDynamic` in favour of using string templates for text content and asset keys. Remove redundant tests that targeted `isDynamic`.
- Refactor out use of assetPrefix in scrollable list button overlays (just title is using it now)