### PR TITLE
[CGPROD-3043] Fixes web audio on safari being stuck in the interrupted state.

### DIFF
--- a/src/core/safari-audio.js
+++ b/src/core/safari-audio.js
@@ -1,0 +1,13 @@
+/**
+ * Resumes the Web Audio Context in Safari when its state is interrupted.
+ * Temporary fix for a bug in Phaser.
+ * See https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/state#resuming_interrupted_play_states_in_ios_safari
+ *
+ * @module core/safari-audio
+ * @copyright BBC 2020
+ * @author BBC Children's D+E
+ * @license Apache-2.0
+ */
+
+export const addResumeSafariAudioContextEvent = game =>
+    window.addEventListener("focus", () => game.sound.context.state === "interrupted" && game.sound.context.resume());

--- a/src/core/startup.js
+++ b/src/core/startup.js
@@ -14,14 +14,16 @@ import { hookErrors } from "./loader/hook-errors.js";
 import * as a11y from "./accessibility/accessibility-layer.js";
 import { addGelButton } from "./layout/gel-game-objects.js";
 import { getPhaserDefaults } from "./loader/phaser-defaults/get-phaser-defaults.js";
+import { addResumeSafariAudioContextEvent } from "./safari-audio.js";
 
-export function startup(config) {
+export const startup = config => {
     setGmi(config.settings || {}, window);
     hookErrors(gmi.gameContainerId);
     Phaser.GameObjects.GameObjectFactory.register("gelButton", addGelButton);
     addCustomStyles();
     const game = new Phaser.Game(getPhaserDefaults(config));
+    addResumeSafariAudioContextEvent(game);
     game.device.audio.mp4 = true;
     debugMode.create(window, game);
     a11y.create();
-}
+};

--- a/test/core/safari-audio.test.js
+++ b/test/core/safari-audio.test.js
@@ -5,7 +5,7 @@
  */
 import { addResumeSafariAudioContextEvent } from "../../src/core/safari-audio.js";
 
-describe("Startup", () => {
+describe("Safari Audio Context", () => {
     let mockGame;
 
     beforeEach(() => {

--- a/test/core/safari-audio.test.js
+++ b/test/core/safari-audio.test.js
@@ -1,0 +1,44 @@
+/**
+ * @copyright BBC 2020
+ * @author BBC Children's D+E
+ * @license Apache-2.0
+ */
+import { addResumeSafariAudioContextEvent } from "../../src/core/safari-audio.js";
+
+describe("Startup", () => {
+    let mockGame;
+
+    beforeEach(() => {
+        global.window.addEventListener = jest.fn();
+        mockGame = {
+            sound: {
+                context: { state: "running", resume: jest.fn() },
+            },
+        };
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    test("adds a focus event listener on window", () => {
+        addResumeSafariAudioContextEvent(mockGame);
+        expect(global.window.addEventListener).toHaveBeenCalledWith("focus", expect.any(Function));
+    });
+
+    test("resumes audio context when blur event fired on window and audio context state is interrupted", () => {
+        addResumeSafariAudioContextEvent(mockGame);
+        mockGame.sound.context.state = "interrupted";
+        const callback = global.window.addEventListener.mock.calls[0][1];
+        callback();
+        expect(mockGame.sound.context.resume).toHaveBeenCalled();
+    });
+
+    test("does not resume audio context when blur event fired on window and audio context state is not interrupted", () => {
+        addResumeSafariAudioContextEvent(mockGame);
+        const callback = global.window.addEventListener.mock.calls[0][1];
+        callback();
+        expect(mockGame.sound.context.resume).not.toHaveBeenCalled();
+    });
+});

--- a/test/core/startup.test.js
+++ b/test/core/startup.test.js
@@ -12,8 +12,10 @@ import * as styles from "../../src/core/custom-styles.js";
 import { startup } from "../../src/core/startup.js";
 import { addGelButton } from "../../src/core/layout/gel-game-objects.js";
 import * as debugModeModule from "../../src/core/debug/debug-mode.js";
+import * as SafariAudio from "../../src/core/safari-audio.js";
 
 jest.mock("../../src/core/custom-styles.js");
+jest.mock("../../src/core/safari-audio.js");
 
 describe("Startup", () => {
     let mockGmi;
@@ -51,6 +53,11 @@ describe("Startup", () => {
 
         startup(config);
         expect(gmiModule.setGmi).toHaveBeenCalledWith(config.settings, global.window);
+    });
+
+    test("adds the resume safari audio context event", () => {
+        startup({ screens: {} });
+        expect(SafariAudio.addResumeSafariAudioContextEvent).toHaveBeenCalledWith(mockGame);
     });
 
     test("enables mp4 audio support for all devices", () => {


### PR DESCRIPTION
Fixes audio in Safari after using a prompt in the debug screen.
This may also fix a previous iOS bug that I remember. That one prevented audio from playing after switching safari tabs or changing app to a different app in iOS.