### PR TITLE
[CGPROD-2812] shop stats

### DIFF
--- a/src/components/shop/menu-buttons.js
+++ b/src/components/shop/menu-buttons.js
@@ -8,12 +8,16 @@
 import { accessibilify } from "../../core/accessibility/accessibilify.js";
 import { CAMERA_X, CAMERA_Y } from "../../core/layout/metrics.js";
 import { addText } from "../../core/layout/text-elem.js";
+import { gmi } from "../../core/gmi/gmi.js";
 
 export const createMenuButtons = container =>
     ["Shop", "Manage"].map(button => {
         const config = getButtonConfig(button, `${button.toLowerCase()}_menu_button`, container.scene);
-        const callback = () => container.scene.stack(button.toLowerCase());
-        return makeButton(container, config, callback); // these buttons need to fire events anyway: they can also fire the screen stat.
+        const callback = () => {
+            container.scene.stack(button.toLowerCase());
+            gmi.setStatsScreen(button === "Shop" ? "shopbuy" : "shopmanage");
+        };
+        return makeButton(container, config, callback);
     });
 
 export const createConfirmButtons = (container, actionText, confirmCallback, cancelCallback) =>

--- a/src/components/shop/menu-buttons.js
+++ b/src/components/shop/menu-buttons.js
@@ -13,7 +13,7 @@ export const createMenuButtons = container =>
     ["Shop", "Manage"].map(button => {
         const config = getButtonConfig(button, `${button.toLowerCase()}_menu_button`, container.scene);
         const callback = () => container.scene.stack(button.toLowerCase());
-        return makeButton(container, config, callback);
+        return makeButton(container, config, callback); // these buttons need to fire events anyway: they can also fire the screen stat.
     });
 
 export const createConfirmButtons = (container, actionText, confirmCallback, cancelCallback) =>

--- a/src/components/shop/shop.js
+++ b/src/components/shop/shop.js
@@ -67,7 +67,8 @@ export class Shop extends Screen {
         this.paneStack.pop();
         if (!this.paneStack.length) {
             this.setVisiblePane("top");
-            this.useOriginalMessage(); // shop screen fires here
+            this.useOriginalMessage();
+            gmi.setStatsScreen("shopmenu");
             return;
         }
         this.setVisiblePane(this.paneStack[this.paneStack.length - 1]);

--- a/src/components/shop/shop.js
+++ b/src/components/shop/shop.js
@@ -67,7 +67,7 @@ export class Shop extends Screen {
         this.paneStack.pop();
         if (!this.paneStack.length) {
             this.setVisiblePane("top");
-            this.useOriginalMessage();
+            this.useOriginalMessage(); // shop screen fires here
             return;
         }
         this.setVisiblePane(this.paneStack[this.paneStack.length - 1]);

--- a/src/components/shop/shop.js
+++ b/src/components/shop/shop.js
@@ -68,7 +68,6 @@ export class Shop extends Screen {
         if (!this.paneStack.length) {
             this.setVisiblePane("top");
             this.useOriginalMessage();
-            gmi.setStatsScreen("shopmenu");
             return;
         }
         this.setVisiblePane(this.paneStack[this.paneStack.length - 1]);
@@ -82,7 +81,10 @@ export class Shop extends Screen {
 
     setVisiblePane(pane) {
         Object.keys(this.panes).forEach(key => this.panes[key] && this.panes[key].setVisible(pane === key));
-        pane === "top" && this.title.setTitleText("Shop");
+        if (pane === "top") {
+            gmi.setStatsScreen("shopmenu");
+            this.title.setTitleText("Shop");
+        }
     }
 
     useCustomMessage() {

--- a/src/components/shop/transact.js
+++ b/src/components/shop/transact.js
@@ -13,8 +13,10 @@ export const buy = (scene, item) => {
     const invCol = collections.get(manage);
     const shopCol = collections.get(shop);
     const inventoryItem = invCol.get(item.id);
-    shopCol.set({ ...item, qty: shopCol.get(item.id).qty - 1 });
+    const remainingStock = shopCol.get(item.id).qty - 1;
+    shopCol.set({ ...item, qty: remainingStock });
     invCol.set({ ...item, state: "purchased", qty: inventoryItem ? inventoryItem.qty + 1 : 1 });
+    gmi.sendStatsEvent("buy", "click", { id: item.id, qty: remainingStock });
     updateBalance(scene, invCol, item.price);
 };
 
@@ -26,6 +28,7 @@ export const equip = (scene, item) => {
         .filter(invItem => invItem.slot === item.slot && invItem.state === "equipped");
     const maxItemsInSlot = scene.config.slots[item.slot].max;
     itemsEquippedInSlot.length === maxItemsInSlot && unequip(scene, itemsEquippedInSlot[0]);
+    gmi.sendStatsEvent("equip", "click", { id: item.id, qty: 1 });
     invCol.set({ ...item, state: "equipped" });
 };
 

--- a/src/components/shop/transact.js
+++ b/src/components/shop/transact.js
@@ -35,6 +35,7 @@ export const equip = (scene, item) => {
 export const unequip = (scene, item) => {
     const { manage } = scene.config.paneCollections;
     const invCol = collections.get(manage);
+    gmi.sendStatsEvent("unequip", "click", { id: item.id, qty: 1 });
     invCol.set({ ...item, state: "purchased" });
 };
 
@@ -42,7 +43,9 @@ export const use = (scene, item) => {
     const { manage } = scene.config.paneCollections;
     const invCol = collections.get(manage);
     const invItem = invCol.get(item.id);
-    invCol.set({ ...invItem, qty: invItem.qty - 1 });
+    const qtyLeft = invItem.qty - 1;
+    gmi.sendStatsEvent("use", "click", { id: item.id, qty: qtyLeft });
+    invCol.set({ ...invItem, qty: qtyLeft });
 };
 
 const updateBalance = (scene, invCol, price) =>

--- a/src/components/shop/transact.js
+++ b/src/components/shop/transact.js
@@ -6,6 +6,7 @@
  */
 
 import { collections } from "../../core/collections.js";
+import { gmi } from "../../core/gmi/gmi.js";
 
 export const buy = (scene, item) => {
     const { shop, manage } = scene.config.paneCollections;

--- a/test/components/shop/menu-buttons.test.js
+++ b/test/components/shop/menu-buttons.test.js
@@ -69,6 +69,7 @@ describe("shop menu buttons", () => {
 
     describe("createMenuButtons()", () => {
         beforeEach(() => (buttons = createMenuButtons(mockContainer)));
+
         test("adds two gel buttons", () => {
             expect(buttons.length).toBe(2);
             expect(mockScene.add.gelButton).toHaveBeenCalledTimes(2);

--- a/test/components/shop/menu-buttons.test.js
+++ b/test/components/shop/menu-buttons.test.js
@@ -94,6 +94,12 @@ describe("shop menu buttons", () => {
             callback();
             expect(mockScene.stack).toHaveBeenCalledWith("shop");
         });
+        test("with a callback that calls scene.stack with the pane title", () => {
+            expect(false).toBe(true);
+        });
+        test("and fires a screen view stat", () => {
+            expect(false).toBe(true);
+        });
         test("sets text overlays", () => {
             expect(mockButton.overlays.set).toHaveBeenCalledTimes(2);
             expect(text.addText.mock.calls[0][3]).toBe("Shop");

--- a/test/components/shop/menu-buttons.test.js
+++ b/test/components/shop/menu-buttons.test.js
@@ -13,6 +13,7 @@ import {
 import { eventBus } from "../../../src/core/event-bus.js";
 import * as a11y from "../../../src/core/accessibility/accessibilify.js";
 import * as text from "../../../src/core/layout/text-elem.js";
+import * as gmi from "../../../src/core/gmi/gmi.js";
 
 describe("shop menu buttons", () => {
     let buttons;
@@ -62,6 +63,7 @@ describe("shop menu buttons", () => {
     const mockEvent = { unsubscribe: "foo" };
     eventBus.subscribe = jest.fn(() => mockEvent);
     a11y.accessibilify = jest.fn(x => x);
+    gmi.setStatsScreen = jest.fn();
 
     afterEach(() => jest.clearAllMocks());
 
@@ -88,17 +90,28 @@ describe("shop menu buttons", () => {
             const otherConfig = { ...expectedConfig, title: "Manage", id: "manage_menu_button", ariaLabel: "Manage" };
             expect(mockScene.add.gelButton.mock.calls[1][2]).toStrictEqual(otherConfig);
         });
-        test("subscribes them to the event bus", () => {
-            expect(mockButton.on).toHaveBeenCalledTimes(2);
-            const callback = mockButton.on.mock.calls[0][1];
-            callback();
-            expect(mockScene.stack).toHaveBeenCalledWith("shop");
-        });
-        test("with a callback that calls scene.stack with the pane title", () => {
-            expect(false).toBe(true);
-        });
-        test("and fires a screen view stat", () => {
-            expect(false).toBe(true);
+        describe("callback", () => {
+            let callback;
+            beforeEach(() => {
+                callback = mockButton.on.mock.calls[0][1];
+            });
+            test("is subscribed to the event bus", () => {
+                expect(mockButton.on).toHaveBeenCalledTimes(2);
+                expect(typeof callback).toBe("function");
+            });
+            test("calls scene.stack with the pane title", () => {
+                callback();
+                expect(mockScene.stack).toHaveBeenCalledWith("shop");
+            });
+            test("and fires a screen view stat with hardcoded 'shopbuy' value", () => {
+                callback();
+                expect(gmi.setStatsScreen).toHaveBeenCalledWith("shopbuy");
+            });
+            test("the other button fires a hardcoded 'shopmanage' value", () => {
+                const otherCallback = mockButton.on.mock.calls[1][1];
+                otherCallback();
+                expect(gmi.setStatsScreen).toHaveBeenCalledWith("shopmanage");
+            });
         });
         test("sets text overlays", () => {
             expect(mockButton.overlays.set).toHaveBeenCalledTimes(2);

--- a/test/components/shop/menu-buttons.test.js
+++ b/test/components/shop/menu-buttons.test.js
@@ -13,7 +13,7 @@ import {
 import { eventBus } from "../../../src/core/event-bus.js";
 import * as a11y from "../../../src/core/accessibility/accessibilify.js";
 import * as text from "../../../src/core/layout/text-elem.js";
-import * as gmi from "../../../src/core/gmi/gmi.js";
+import { gmi } from "../../../src/core/gmi/gmi.js";
 
 describe("shop menu buttons", () => {
     let buttons;

--- a/test/components/shop/shop.test.js
+++ b/test/components/shop/shop.test.js
@@ -53,6 +53,7 @@ describe("Shop", () => {
     const mockConfirm = { container: { foo: "bar" }, setVisible: jest.fn(), resize: jest.fn(), destroy: jest.fn() };
     const mockTitles = { setTitleText: jest.fn(), setScale: jest.fn(), setPosition: jest.fn() };
 
+    gmi.setStatsScreen = jest.fn();
     beforeEach(() => {
         config = {
             shop: {
@@ -167,6 +168,9 @@ describe("Shop", () => {
             expect(mockMenu.setVisible).toHaveBeenCalledWith(true);
             expect(mockScrollableList.setVisible).toHaveBeenCalledTimes(2);
         });
+        test("fires a screen view stat with hardcoded 'shopmenu'", () => {
+            expect(gmi.setStatsScreen).toHaveBeenCalledWith("shopmenu");
+        });
 
         describe("registers with the scaler", () => {
             test("subscribes to onScaleChange", () => {
@@ -241,8 +245,8 @@ describe("Shop", () => {
                 expect(eventBus.subscribe).toHaveBeenCalledWith(shopScreen.backMessage);
                 expect(eventBus.removeSubscription).toHaveBeenCalledWith(shopScreen.customMessage);
             });
-            test("fires a menu view stat", () => {
-                expect(false).toBe(true);
+            test("fires a screen view stat with hardcoded 'shopmenu'", () => {
+                expect(gmi.setStatsScreen).toHaveBeenCalledWith("shopmenu");
             });
         });
     });

--- a/test/components/shop/shop.test.js
+++ b/test/components/shop/shop.test.js
@@ -241,6 +241,9 @@ describe("Shop", () => {
                 expect(eventBus.subscribe).toHaveBeenCalledWith(shopScreen.backMessage);
                 expect(eventBus.removeSubscription).toHaveBeenCalledWith(shopScreen.customMessage);
             });
+            test("fires a menu view stat", () => {
+                expect(false).toBe(true);
+            });
         });
     });
     describe("resize()", () => {

--- a/test/components/shop/transact.test.js
+++ b/test/components/shop/transact.test.js
@@ -7,8 +7,10 @@
 
 import * as transact from "../../../src/components/shop/transact.js";
 import { collections } from "../../../src/core/collections.js";
+import { gmi } from "../../../src/core/gmi/gmi.js";
 
 jest.mock("../../../src/core/collections.js");
+jest.mock("../../../src/core/gmi/gmi.js");
 
 describe("Shop Transactions", () => {
     let mockScene;
@@ -67,6 +69,7 @@ describe("Shop Transactions", () => {
             get: jest.fn(itemId => (itemId === "currency" ? mockCurrencyItem : mockInventoryItem)),
             set: jest.fn(),
         };
+        gmi.sendStatsEvent = jest.fn();
     });
     afterEach(() => jest.clearAllMocks());
 
@@ -100,6 +103,10 @@ describe("Shop Transactions", () => {
             transact.buy(mockScene, mockItem);
             expect(mockScene.events.emit).toHaveBeenCalledWith("updatebalance");
         });
+
+        test("fires a stats event", () => {
+            expect(gmi.sendStatsEvent).toHaveBeenCalledWith("foo", "bar");
+        });
     });
 
     describe("Equipping an item", () => {
@@ -118,6 +125,9 @@ describe("Shop Transactions", () => {
             transact.equip(mockScene, mockItem);
             expect(mockManageCollection.set).toHaveBeenCalledWith(expectedItem);
         });
+        test("fires a stats event", () => {
+            expect(gmi.sendStatsEvent).toHaveBeenCalledWith("foo", "bar");
+        });
     });
 
     describe("Unequipping an item", () => {
@@ -127,6 +137,9 @@ describe("Shop Transactions", () => {
             transact.unequip(mockScene, mockItem);
             expect(mockManageCollection.set).toHaveBeenCalledWith(expectedItem);
         });
+        test("fires a stats event", () => {
+            expect(gmi.sendStatsEvent).toHaveBeenCalledWith("foo", "bar");
+        });
     });
 
     describe("using an item", () => {
@@ -134,6 +147,9 @@ describe("Shop Transactions", () => {
             const expectedItem = { ...mockInventoryItem, qty: mockInventoryItem.qty - 1 };
             transact.use(mockScene, mockInventoryItem);
             expect(mockManageCollection.set).toHaveBeenCalledWith(expectedItem);
+        });
+        test("fires a stats event", () => {
+            expect(gmi.sendStatsEvent).toHaveBeenCalledWith("foo", "bar");
         });
     });
 

--- a/test/components/shop/transact.test.js
+++ b/test/components/shop/transact.test.js
@@ -147,11 +147,11 @@ describe("Shop Transactions", () => {
             const expectedItem = { ...mockItem, state: "purchased" };
             expect(mockManageCollection.set).toHaveBeenCalledWith(expectedItem);
         });
-        // test("fires a stats event", () => {
-        //     expect(gmi.sendStatsEvent.mock.calls[0][0]).toBe("unequip");
-        //     expect(gmi.sendStatsEvent.mock.calls[0][1]).toBe("click");
-        //     expect(gmi.sendStatsEvent.mock.calls[0][2]).toStrictEqual({ id: "someId", qty: 1 });
-        // });
+        test("fires a stats event", () => {
+            expect(gmi.sendStatsEvent.mock.calls[0][0]).toBe("unequip");
+            expect(gmi.sendStatsEvent.mock.calls[0][1]).toBe("click");
+            expect(gmi.sendStatsEvent.mock.calls[0][2]).toStrictEqual({ id: "item", qty: 1 });
+        });
     });
 
     describe("using an item", () => {
@@ -161,11 +161,11 @@ describe("Shop Transactions", () => {
             const expectedItem = { ...mockInventoryItem, qty: mockInventoryItem.qty - 1 };
             expect(mockManageCollection.set).toHaveBeenCalledWith(expectedItem);
         });
-        // test("fires a stats event", () => {
-        //     expect(gmi.sendStatsEvent.mock.calls[0][0]).toBe("use");
-        //     expect(gmi.sendStatsEvent.mock.calls[0][1]).toBe("click");
-        //     expect(gmi.sendStatsEvent.mock.calls[0][2]).toStrictEqual({ id: "inventoryItem", qty: 4 });
-        // });
+        test("fires a stats event", () => {
+            expect(gmi.sendStatsEvent.mock.calls[0][0]).toBe("use");
+            expect(gmi.sendStatsEvent.mock.calls[0][1]).toBe("click");
+            expect(gmi.sendStatsEvent.mock.calls[0][2]).toStrictEqual({ id: "inventoryItem", qty: 4 });
+        });
     });
 
     describe("getBalanceItem", () => {

--- a/test/components/shop/transact.test.js
+++ b/test/components/shop/transact.test.js
@@ -97,9 +97,7 @@ describe("Shop Transactions", () => {
         });
 
         test("fires a stats event", () => {
-            expect(gmi.sendStatsEvent.mock.calls[0][0]).toBe("buy");
-            expect(gmi.sendStatsEvent.mock.calls[0][1]).toBe("click");
-            expect(gmi.sendStatsEvent.mock.calls[0][2]).toStrictEqual({ id: "item", qty: 0 });
+            expect(gmi.sendStatsEvent).toHaveBeenCalledWith("buy", "click", { id: "item", qty: 0 });
         });
 
         test("item is added to the inventory collection with qty set to 1 when the item does not exist in the inventory yet", () => {
@@ -120,9 +118,7 @@ describe("Shop Transactions", () => {
         });
 
         test("fires a stats event", () => {
-            expect(gmi.sendStatsEvent.mock.calls[0][0]).toBe("equip");
-            expect(gmi.sendStatsEvent.mock.calls[0][1]).toBe("click");
-            expect(gmi.sendStatsEvent.mock.calls[0][2]).toStrictEqual({ id: "item", qty: 1 });
+            expect(gmi.sendStatsEvent).toHaveBeenCalledWith("equip", "click", { id: "item", qty: 1 });
         });
 
         test("currently equipped item is unequipped when destination slot is full", () => {
@@ -148,9 +144,7 @@ describe("Shop Transactions", () => {
             expect(mockManageCollection.set).toHaveBeenCalledWith(expectedItem);
         });
         test("fires a stats event", () => {
-            expect(gmi.sendStatsEvent.mock.calls[0][0]).toBe("unequip");
-            expect(gmi.sendStatsEvent.mock.calls[0][1]).toBe("click");
-            expect(gmi.sendStatsEvent.mock.calls[0][2]).toStrictEqual({ id: "item", qty: 1 });
+            expect(gmi.sendStatsEvent).toHaveBeenCalledWith("unequip", "click", { id: "item", qty: 1 });
         });
     });
 
@@ -162,9 +156,7 @@ describe("Shop Transactions", () => {
             expect(mockManageCollection.set).toHaveBeenCalledWith(expectedItem);
         });
         test("fires a stats event", () => {
-            expect(gmi.sendStatsEvent.mock.calls[0][0]).toBe("use");
-            expect(gmi.sendStatsEvent.mock.calls[0][1]).toBe("click");
-            expect(gmi.sendStatsEvent.mock.calls[0][2]).toStrictEqual({ id: "inventoryItem", qty: 4 });
+            expect(gmi.sendStatsEvent).toHaveBeenCalledWith("use", "click", { id: "inventoryItem", qty: 4 });
         });
     });
 

--- a/test/components/shop/transact.test.js
+++ b/test/components/shop/transact.test.js
@@ -54,6 +54,7 @@ describe("Shop Transactions", () => {
             qty: 1,
         };
         mockInventoryItem = {
+            id: "inventoryItem",
             qty: 5,
         };
         mockInventoryItemList = [];
@@ -74,6 +75,7 @@ describe("Shop Transactions", () => {
     afterEach(() => jest.clearAllMocks());
 
     describe("Buying an item", () => {
+        // refactor these tests
         test("item quantity is reduced by 1 in the shop collection", () => {
             const expectedItem = { ...mockItem, qty: mockShopItem.qty - 1 };
             transact.buy(mockScene, mockItem);
@@ -105,7 +107,10 @@ describe("Shop Transactions", () => {
         });
 
         test("fires a stats event", () => {
-            expect(gmi.sendStatsEvent).toHaveBeenCalledWith("foo", "bar");
+            transact.buy(mockScene, mockItem);
+            expect(gmi.sendStatsEvent.mock.calls[0][0]).toBe("buy");
+            expect(gmi.sendStatsEvent.mock.calls[0][1]).toBe("click");
+            expect(gmi.sendStatsEvent.mock.calls[0][2]).toStrictEqual({ id: "item", state: "purchased", qty: 0 });
         });
     });
 
@@ -126,7 +131,14 @@ describe("Shop Transactions", () => {
             expect(mockManageCollection.set).toHaveBeenCalledWith(expectedItem);
         });
         test("fires a stats event", () => {
-            expect(gmi.sendStatsEvent).toHaveBeenCalledWith("foo", "bar");
+            transact.equip(mockScene, mockItem);
+            expect(gmi.sendStatsEvent.mock.calls[0][0]).toBe("equip");
+            expect(gmi.sendStatsEvent.mock.calls[0][1]).toBe("click");
+            expect(gmi.sendStatsEvent.mock.calls[0][2]).toStrictEqual({
+                id: "itemBeingEquipped",
+                state: "equipped",
+                qty: 0,
+            });
         });
     });
 
@@ -138,7 +150,10 @@ describe("Shop Transactions", () => {
             expect(mockManageCollection.set).toHaveBeenCalledWith(expectedItem);
         });
         test("fires a stats event", () => {
-            expect(gmi.sendStatsEvent).toHaveBeenCalledWith("foo", "bar");
+            transact.unequip(mockScene, mockItem);
+            expect(gmi.sendStatsEvent.mock.calls[0][0]).toBe("unequip");
+            expect(gmi.sendStatsEvent.mock.calls[0][1]).toBe("click");
+            expect(gmi.sendStatsEvent.mock.calls[0][2]).toStrictEqual({ id: "someId", qty: 1 });
         });
     });
 
@@ -149,7 +164,10 @@ describe("Shop Transactions", () => {
             expect(mockManageCollection.set).toHaveBeenCalledWith(expectedItem);
         });
         test("fires a stats event", () => {
-            expect(gmi.sendStatsEvent).toHaveBeenCalledWith("foo", "bar");
+            transact.use(mockScene, mockInventoryItem);
+            expect(gmi.sendStatsEvent.mock.calls[0][0]).toBe("use");
+            expect(gmi.sendStatsEvent.mock.calls[0][1]).toBe("click");
+            expect(gmi.sendStatsEvent.mock.calls[0][2]).toStrictEqual({ id: "inventoryItem", qty: 4 });
         });
     });
 


### PR DESCRIPTION
- fires a `'shopmenu'` stat on create()
- Menu button callbacks fire `'shopbuy'` and `'shopmanage'` page view stats
- shop.back() fires a stat if the target pane is the top menu
- all transactions fire item action stats
- refactor transact.test.js to be more DRY