### PR TITLE
GGPROD-3073 Added routes for shop navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | Added routes for shop navigation, fixes pause bug. |
 | | Local dev ports have been changed to `9000` for `npm run start` and `9001` for `npm run start:pack` for compatibility with Cypress tests. |
 | 3.8.11 ||
 | | Roll Phaser back to 2.34.1 due to rex plugin incompatibilities. |

--- a/src/main.js
+++ b/src/main.js
@@ -102,6 +102,9 @@ const screens = {
     // Overlays
     shop: {
         scene: Shop,
+        routes: {
+            home: "home",
+        },
     },
     "how-to-play": {
         scene: HowToPlay,


### PR DESCRIPTION
fixes pause bug when checking for `restart` and `select` routes.