### PR TITLE
CGPROD-3129 getRect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | Added resize for shop menu based on re-calculated bounds. |
 | | theme/items renamed to theme/collections. |
 | | Added routes for shop navigation, fixes pause bug. |
 | | Local dev ports have been changed to `9000` for `npm run start` and `9001` for `npm run start:pack` for compatibility with Cypress tests. |

--- a/src/components/shop/menu.js
+++ b/src/components/shop/menu.js
@@ -7,17 +7,30 @@
 import { createMenuButtons, resizeGelButtons } from "./menu-buttons.js";
 import { getInnerRectBounds, getSafeArea } from "./shop-layout.js";
 
-export const createMenu = scene => {
+const getRect = scene => {
     const bounds = getSafeArea(scene.layout);
     const innerBounds = getInnerRectBounds(scene);
-
     const rect = scene.add.rectangle(innerBounds.x, innerBounds.y, innerBounds.width, innerBounds.height, 0x000000, 0);
+
+    rect.setSize(innerBounds.width, innerBounds.height);
     rect.setY(bounds.height / 2 + bounds.y);
 
+    return rect;
+};
+
+export const createMenu = scene => {
+    const rect = getRect(scene);
     const buttons = createMenuButtons(scene);
+
     resizeGelButtons({ buttons, rect });
 
+    const resize = () => {
+        const rect = getRect(scene);
+
+        resizeGelButtons({ buttons, rect });
+    };
+
     return {
-        resize: () => resizeGelButtons({ buttons, rect }),
+        resize,
     };
 };

--- a/test/components/shop/menu.test.js
+++ b/test/components/shop/menu.test.js
@@ -23,7 +23,7 @@ describe("shop menu", () => {
     beforeEach(() => {
         mockMenuButtons = { mock: "buttons" };
         mockPaneBackground = { mock: "background" };
-        mockRectangle = { mock: "rectangle", setY: jest.fn() };
+        mockRectangle = { mock: "rectangle", setY: jest.fn(), setSize: jest.fn() };
         mockInnerRectBounds = { width: 100, height: 100, x: 0, y: 0 };
         mockScene = {
             add: {
@@ -60,6 +60,9 @@ describe("shop menu", () => {
         });
         test("calls setY on the rect with an appropriate Y offset", () => {
             expect(mockRectangle.setY).toHaveBeenCalledWith(200);
+        });
+        test("calls setSize on the rect with the appropriate width, height", () => {
+            expect(mockRectangle.setSize).toHaveBeenCalledWith(mockInnerRectBounds.width, mockInnerRectBounds.height);
         });
         test("menu resize function calls resizeGelButtons", () => {
             jest.clearAllMocks();


### PR DESCRIPTION
Adds resize for shop menu based on re-calculated bounds.

When resizing the window, the buttons will now better recalculate their correct
size when the bounds have significantly changed.