### PR TITLE
CGPROD-3128 Fix showing shop confirm on key press

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | Fix showing shop confirm on key press. |
 | | Added resize for shop menu based on re-calculated bounds. |
 | | theme/items renamed to theme/collections. |
 | | Added routes for shop navigation, fixes pause bug. |

--- a/src/components/shop/scrollable-list/scrollable-list.js
+++ b/src/components/shop/scrollable-list/scrollable-list.js
@@ -39,8 +39,14 @@ const showConfirmation = (scene, mode, item) => {
 };
 
 const createItem = (scene, item, mode, parent, scrollablePanel) => {
-    const action = pointer =>
-        (scrollablePanel.isInTouching() || !pointer) && !isLocked(item) && showConfirmation(scene, mode, item);
+    const action = pointer => {
+        const prevType = pointer.screen.input.keyboard.prevType;
+        return (
+            (scrollablePanel.isInTouching() || !pointer || prevType === "keydown") &&
+            !isLocked(item) &&
+            showConfirmation(scene, mode, item)
+        );
+    };
     const icon = createListButton(scene, item, mode, action, parent);
 
     return scene.rexUI.add.label({

--- a/test/components/shop/scrollable-list/scrollable-list.test.js
+++ b/test/components/shop/scrollable-list/scrollable-list.test.js
@@ -53,6 +53,7 @@ describe("Scrollable List", () => {
     let mockItem;
     let mockLabel;
     let mockGmi;
+    let mockPointer;
 
     afterEach(jest.clearAllMocks);
     beforeEach(() => {
@@ -164,6 +165,15 @@ describe("Scrollable List", () => {
                         shopCollections: {
                             shop: "testCatalogue",
                         },
+                    },
+                },
+            },
+        };
+        mockPointer = {
+            screen: {
+                input: {
+                    keyboard: {
+                        prevType: "",
                     },
                 },
             },
@@ -301,19 +311,25 @@ describe("Scrollable List", () => {
                 beforeEach(() => {
                     callback = buttons.createListButton.mock.calls[0][3];
                 });
-
+                afterEach(() => {
+                    jest.clearAllMocks();
+                });
                 test("creates a confirm pane", () => {
-                    callback();
+                    callback(mockPointer);
                     expect(mockScene.transientData.shop.mode).toBe("shop");
                     expect(mockScene.transientData.shop.item).toBe(mockItem);
                     expect(mockScene.scene.pause).toHaveBeenCalled();
                     expect(mockScene.addOverlay).toHaveBeenCalledWith("shop-confirm");
                 });
                 test("don't fire if the label is scrolled off the panel", () => {
-                    jest.clearAllMocks();
                     mockScrollablePanel.isInTouching = jest.fn(() => false);
-                    callback("mockPointer");
-                    expect(confirm.createConfirm).not.toHaveBeenCalled();
+                    callback(mockPointer);
+                    expect(mockScene.addOverlay).not.toHaveBeenCalledWith("shop-confirm");
+                });
+                test("show confirm if the label is fired by keydown event", () => {
+                    mockPointer.screen.input.keyboard.prevType = "keydown";
+                    callback(mockPointer);
+                    expect(mockScene.addOverlay).toHaveBeenCalledWith("shop-confirm");
                 });
             });
         });


### PR DESCRIPTION
Key press was not being recognised when no pointer events had previously been fired, added condition for `keydown` on event to call `showConfirmation`.

- Fixes using the return/space key to navigate to shop confirm screen when only tabbing.

- Fixes some unit tests that were not testing anything.

