### PR TITLE
CGPROD-3156 Reposition shop-list a11y elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | Reposition shop-list accessible elements on scroll and tab events. |
 | | Fix showing shop confirm on key press. |
 | | Added resize for shop menu based on re-calculated bounds. |
 | | theme/items renamed to theme/collections. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -2590,6 +2590,16 @@
             "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
             "dev": true
         },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
         "blob-util": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -2978,7 +2988,11 @@
                     "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
                     "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "bindings": "^1.5.0",
+                        "nan": "^2.12.1"
+                    }
                 },
                 "glob-parent": {
                     "version": "3.1.0",
@@ -5208,6 +5222,13 @@
             "requires": {
                 "flat-cache": "^2.0.1"
             }
+        },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "dev": true,
+            "optional": true
         },
         "fill-range": {
             "version": "7.0.1",
@@ -9524,6 +9545,13 @@
                 "object-assign": "^4.0.1",
                 "thenify-all": "^1.0.0"
             }
+        },
+        "nan": {
+            "version": "2.14.2",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+            "dev": true,
+            "optional": true
         },
         "nanomatch": {
             "version": "1.2.13",

--- a/src/components/shop/scrollable-list/scrollable-list-handlers.js
+++ b/src/components/shop/scrollable-list/scrollable-list-handlers.js
@@ -51,6 +51,11 @@ const wheelScrollFactor = panel => {
     return 1 / maxOffset;
 };
 
+const resetElements = panel => {
+    const items = getPanelItems(panel);
+    items.forEach(label => label.children[0].setElementSizeAndPosition());
+};
+
 export const updatePanelOnFocus = panel => rexLabel => {
     const visibleBounds = getVisibleRangeBounds(panel);
     const itemBounds = getItemBounds(panel, rexLabel);
@@ -60,6 +65,7 @@ export const updatePanelOnFocus = panel => rexLabel => {
         [() => true, () => {}],
     ]);
     updateScrollPositionIfItemNotVisible(visibleBounds, itemBounds);
+    resetElements(panel);
 };
 
 export const updatePanelOnWheel = panel => (...args) => {
@@ -72,4 +78,5 @@ export const updatePanelOnWheel = panel => (...args) => {
     const delta = deltaY * wheelScrollFactor(panel);
     const t = Math.min(Math.max(0, panel.t + delta), 1);
     panel.t !== t && panel.setT(t);
+    resetElements(panel);
 };

--- a/test/components/shop/scrollable-list/scrollable-list-handlers.test.js
+++ b/test/components/shop/scrollable-list/scrollable-list-handlers.test.js
@@ -9,12 +9,13 @@
 import * as handlers from "../../../../src/components/shop/scrollable-list/scrollable-list-handlers.js";
 
 let mockGelButton;
+let mockOtherGelButton;
 let mockRexLabel;
+let mockOtherRexLabel;
 let mockGridSizer;
 let mockPanel;
 
 const mockSizer = { innerHeight: 300, space: { top: 10 } };
-const mockOtherRexLabel = { children: [{}], height: 100 };
 
 describe("Scrollable List handlers", () => {
     afterEach(() => {
@@ -31,6 +32,9 @@ describe("Scrollable List handlers", () => {
                 },
             },
         };
+        mockOtherGelButton = {
+            setElementSizeAndPosition: jest.fn(),
+        };
         mockRexLabel = {
             children: [mockGelButton],
             height: 100,
@@ -38,6 +42,7 @@ describe("Scrollable List handlers", () => {
             setInteractive: jest.fn(() => mockRexLabel),
             disableInteractive: jest.fn(() => mockRexLabel),
         };
+        mockOtherRexLabel = { children: [mockOtherGelButton], height: 100 };
         mockGridSizer = { getElement: jest.fn(() => [mockRexLabel]) };
         mockPanel = {
             getByName: jest.fn(() => mockGridSizer),
@@ -121,6 +126,21 @@ describe("Scrollable List handlers", () => {
             expect(t).toBeLessThan(1);
             expect(t).toBeGreaterThan(0.5);
         });
+        test("updates a11y elements position on focus", () => {
+            mockGridSizer = {
+                getElement: jest.fn(() => [mockRexLabel]),
+            };
+            mockPanel = {
+                getByName: jest.fn(() => mockGridSizer),
+                space: { top: 10 },
+                setT: jest.fn(),
+                minHeight: 150,
+                t: 1,
+            };
+            const update = handlers.updatePanelOnFocus(mockPanel);
+            update(mockRexLabel);
+            expect(mockGelButton.setElementSizeAndPosition).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe("updatePanelOnWheel", () => {
@@ -149,6 +169,11 @@ describe("Scrollable List handlers", () => {
             onWheelFn(...args);
             expect(mockPanel.setT).not.toHaveBeenCalled();
             expect(mockEvent.stopPropagation).toHaveBeenCalled();
+        });
+        test("updates a11y elements position on scroll.", () => {
+            const onWheelFn = handlers.updatePanelOnWheel(mockPanel);
+            onWheelFn(...args);
+            expect(mockGelButton.setElementSizeAndPosition).toHaveBeenCalledTimes(1);
         });
     });
 });


### PR DESCRIPTION
Reposition shop-list accessible elements on scroll and tab events.

Fixes bug CGPROD-3156