### PR TITLE
[CGPROD-3238] Fix distorted audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 | Version | Description |
 |---------|-------------|
-| 3.9.11 | |
+| 3.9.2 | |
+| | Updated Phaser to 3.55.2 |
+| | Fixed distorted audio in the shop screens on some iOS devices. |
+| 3.9.1 | |
 | | Ensures shop confirm buttons have spacing that coheres with GELie. |
 | | Fixes macOS voiceover control + option + space click not working on accessible elements. |
 | | Loads other variations of the Reith font upfront. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "genie",
-    "version": "3.9.0",
+    "version": "3.9.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -9956,9 +9956,9 @@
             "dev": true
         },
         "phaser": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.55.0.tgz",
-            "integrity": "sha512-hkgWstdCJ1K/1BJa8ECmNtLbAQ2qB9JFIZ1lsVh3/KeOd80WsbZbAzqyJrExp5y5Qj9D8UOJTz7p4bJQDdIW7A==",
+            "version": "3.55.2",
+            "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.55.2.tgz",
+            "integrity": "sha512-amKXsbb2Ht29dGPKvt1edq3yGGYKtq8373GpJYGKPNPnneYY6MtVTOgjHDuZwtmUyK4v86FugkT3hzW/N4tjxQ==",
             "requires": {
                 "eventemitter3": "^4.0.7",
                 "path": "^0.12.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "genie",
-    "version": "3.9.1",
+    "version": "3.9.2",
     "description": "BBC Games Genie - A Modular Game Engine",
     "license": "Apache-2.0",
     "private": true,
@@ -25,7 +25,7 @@
         "expose-loader": "^0.7.5",
         "json5": "^2.1.3",
         "notp": "^2.0.3",
-        "phaser": "3.55.0",
+        "phaser": "3.55.2",
         "webfontloader": "^1.6.28"
     },
     "devDependencies": {

--- a/src/core/layout/gel-button.js
+++ b/src/core/layout/gel-button.js
@@ -113,7 +113,7 @@ export class GelButton extends Phaser.GameObjects.Container {
 
     setClickSound(key) {
         this.config.clickSound = key;
-        this._click = this.scene.sound.add(key);
+        this._click = this.scene.sound.get(key) ? this.scene.sound.get(key) : this.scene.sound.add(key);
     }
 
     setImage(key) {

--- a/src/core/music.js
+++ b/src/core/music.js
@@ -15,7 +15,7 @@ let music;
 const isPlaying = audioKey => audioKey && audioKey === music?.key;
 
 const startNext = scene => {
-    music?.destroy();
+    scene.sound.remove(music);
     music = start(scene, scene.config.music);
 };
 

--- a/test/core/layout/gel-button.test.js
+++ b/test/core/layout/gel-button.test.js
@@ -85,6 +85,7 @@ describe("Gel Button", () => {
             },
             sound: {
                 add: jest.fn(() => GameSound.Assets.buttonClick),
+                get: jest.fn(),
             },
             anims: {
                 once: jest.fn(),
@@ -275,6 +276,15 @@ describe("Gel Button", () => {
             const gelButton = new GelButton(mockScene, mockX, mockY, mockConfig);
             const mockSound = { testProp: "testValue" };
             (mockScene.sound.add = jest.fn(() => mockSound)), gelButton.setClickSound("test-key");
+
+            expect(gelButton.config.clickSound).toBe("test-key");
+            expect(gelButton._click).toBe(mockSound);
+        });
+
+        test("gets the sound from sound manager when it already exists", () => {
+            const gelButton = new GelButton(mockScene, mockX, mockY, mockConfig);
+            const mockSound = { testProp: "testValue" };
+            (mockScene.sound.get = jest.fn(() => mockSound)), gelButton.setClickSound("test-key");
 
             expect(gelButton.config.clickSound).toBe("test-key");
             expect(gelButton._click).toBe(mockSound);

--- a/test/core/music.test.js
+++ b/test/core/music.test.js
@@ -90,13 +90,13 @@ describe("Game Sound", () => {
             });
 
             test("does not stop current music playing", () => {
-                expect(mockMusic.destroy).not.toHaveBeenCalled();
+                expect(mockScene.sound.remove).not.toHaveBeenCalled();
             });
 
             test("does not stop current music playing if screen is an overlay", () => {
                 mockScene._data.addedBy = "screen";
                 setMusic(mockScene);
-                expect(mockMusic.destroy).not.toHaveBeenCalled();
+                expect(mockScene.sound.remove).not.toHaveBeenCalled();
             });
         });
 
@@ -120,7 +120,7 @@ describe("Game Sound", () => {
             test("fades and stops current music playing if not going to the Home screen", () => {
                 setMusic(mockScene);
                 expect(mockScene.tweens.add).toHaveBeenCalledWith(expect.objectContaining(fadeTween));
-                expect(mockMusic.destroy).toHaveBeenCalled();
+                expect(mockScene.sound.remove).toHaveBeenCalled();
             });
 
             test("stops but doesn't fade current music playing if going to the Home screen", () => {
@@ -128,7 +128,7 @@ describe("Game Sound", () => {
                 // the game music does not fade out before playing the Home screen music.
                 mockScene.scene.key = "home";
                 setMusic(mockScene);
-                expect(mockMusic.destroy).toHaveBeenCalled();
+                expect(mockScene.sound.remove).toHaveBeenCalled();
                 expect(mockScene.tweens.add).not.toHaveBeenCalledWith(expect.objectContaining(fadeTween));
             });
 


### PR DESCRIPTION
SoundManager can add multiple sounds under the same asset key (allows for different sound configs for the same asset).
So calling `scene.sound.add()` adds an extra sound to the manager each time.
We were calling `scene.sound.add()` on each button in the scene, so after loading the scene multiple times, there were a lot of sounds added, causing the distorted audio.

`.get()` will get the first sound
`.getAll()` would return an array of sounds under that key.
 https://photonstorm.github.io/phaser3-docs/Phaser.Sound.WebAudioSoundManager.html#get__anchor