### PR TITLE
[CGPROD-3889] level select fix

### DIFF
--- a/cypress/integration/select_spec.js
+++ b/cypress/integration/select_spec.js
@@ -111,6 +111,8 @@ describe(`The Select screens ${Cypress.env("THEME")}`, () => {
 	it("Scrolls to the page where the last selected item is after a page-refresh", () => {
 		cy.genieClick("#home__debug");
 		cy.genieClick("#debug__debug-select-grid");
+		cy.genieClick("#debug-select-grid__kyle").wait(2000);
+		cy.genieClick("#debug__debug-select-grid").wait(2000);
 		cy.genieClick("#debug-select-grid__next").wait(2000);
 		cy.genieClick("#debug-select-grid__mike").wait(2000);
 		cy.visit(appendToken(`${Cypress.env("url")}${getUrl()}`));

--- a/src/core/collections.js
+++ b/src/core/collections.js
@@ -66,10 +66,8 @@ export const initCollection = screen => key => {
 
 			if (isNewlyUnique) {
 				set({ id, [key]: value });
-				item[key] = value;
 			} else if (shouldBeReset) {
 				set({ id: item.id, [key]: null });
-				item[key] = null;
 			}
 		});
 	};

--- a/src/core/collections.js
+++ b/src/core/collections.js
@@ -60,7 +60,7 @@ export const initCollection = screen => key => {
 	};
 
 	const setUnique = ({ id, key, value }) => {
-		catalogue.forEach(item => {
+		getAll().forEach(item => {
 			const isNewlyUnique = item.id === id && item[key] !== value;
 			const shouldBeReset = item.id !== id && item.hasOwnProperty(key) && item[key] === value;
 
@@ -74,7 +74,7 @@ export const initCollection = screen => key => {
 		});
 	};
 
-	const getUnique = ({ key, value }) => catalogue.find(item => item[key] === value);
+	const getUnique = ({ key, value }) => getAll().find(item => item[key] === value);
 
 	const collection = {
 		config,

--- a/test/core/collections.test.js
+++ b/test/core/collections.test.js
@@ -318,8 +318,6 @@ describe("Collections", () => {
 				id: "id1",
 				selected: true,
 			});
-			expect(collection.getAll()[0].selected).toBe(true);
-			expect(collection.getAll()[1].selected).not.toBe(true);
 		});
 		test("Enforces uniqueness of value in collection", () => {
 			testCatalogue[0].selected = true;
@@ -331,19 +329,24 @@ describe("Collections", () => {
 				id: "id2",
 				selected: null,
 			});
-			expect(collection.getAll()[0].selected).toBe(true);
-			expect(collection.getAll()[1].selected).toBe(null);
 		});
 	});
 
 	describe("Returned getUnique method", () => {
-		test("Returns unique element by key from collection if exists", () => {
+		test("Returns undefined when unique element does not exist", () => {
 			const collection = initCollection(mockScreen)("testCollection");
-			collection.setUnique({ id: "id1", key: "selected", value: true });
+
+			expect(collection.getUnique({ key: "selected", value: true })).toEqual(undefined);
+		});
+		test("Returns unique element by key from collection if exists", () => {
+			testCatalogue[0].selected = true;
+			const collection = initCollection(mockScreen)("testCollection");
+
 			expect(collection.getUnique({ key: "selected", value: true })).toEqual({
 				description: "Catalogue Item 1.",
 				id: "id1",
 				selected: true,
+				qty: 1,
 				tags: ["tag1"],
 				title: "Title 1",
 			});


### PR DESCRIPTION
Ticket: https://jira.dev.bbc.co.uk/browse/CGPROD-3889

- update to use catalogue with the local storage items merged into it with `getAll()`
- update relevant unit/integration tests