### PR TITLE
[CGPROD-3891] top right buttons - vertical option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 | Version       | Description                                                                                                                                           |
 |---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-|               | Breaking change: selections are now saved in collections/local storage.
+|               | Added option for vertical layout for top right layout group.                                                                                          |
+|               | Breaking change: selections are now saved in collections/local storage.                                                                               |
 | 3.15.0        | Updated Spine Plugin and example files to Spine 4.1.                                                                                                  |
 |               | Added rollup build for ninepatch plugin and updated.                                                                                                  |
 |               | Added docs for building libraries to ES6 with rollup.                                                                                                 |

--- a/docs/development/global-config.md
+++ b/docs/development/global-config.md
@@ -1,0 +1,15 @@
+# Global Config
+
+The global config file should be placed in [themes/default/config.json] with the available configuration keys as below:
+
+```
+{
+    "topRightVertical": false
+    ...
+}
+```
+
+## Available configuration keys
+
+### `topRightVertical`
+Sets the layout of the top right group to be vertical.

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -20,7 +20,7 @@ const addChannelToAll = (defaults, channel) => Object.fromEntries(Object.entries
 
 export const buttonsChannel = screen => (screen ? `gel-buttons-${screen.scene.key}` : "gel-buttons");
 export const config = screen => {
-	const { verticalTopRight } = screen?.cache.json.get("game-config") || {};
+	const { topRightVertical } = screen?.cache.json.get("config") || {};
 
 	const gelDefaults = {
 		exit: {
@@ -72,7 +72,7 @@ export const config = screen => {
 			},
 		},
 		audio: {
-			group: verticalTopRight ? "topRightV" : "topRight",
+			group: topRightVertical ? "topRightV" : "topRight",
 			title: "Sound Off",
 			key: "audio-on",
 			ariaLabel: "Toggle Sound",
@@ -91,7 +91,7 @@ export const config = screen => {
 			},
 		},
 		settings: {
-			group: verticalTopRight ? "topRightV" : "topRight",
+			group: topRightVertical ? "topRightV" : "topRight",
 			title: "Settings",
 			key: "settings",
 			ariaLabel: "Game Settings",
@@ -102,7 +102,7 @@ export const config = screen => {
 			},
 		},
 		pause: {
-			group: verticalTopRight ? "topRightV" : "topRight",
+			group: topRightVertical ? "topRightV" : "topRight",
 			title: "Pause",
 			key: "pause",
 			ariaLabel: "Pause Game",

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -7,6 +7,9 @@ import { settings, settingsChannel } from "../settings.js";
 import { gmi } from "../gmi/gmi.js";
 import { eventBus } from "../event-bus.js";
 import { collections } from "../../core/collections.js";
+// \---> TODO: find the right place to load game-config
+import gameConfig from "../../../themes/default/game-config.json" assert { type: "json" };
+// <---|
 
 const pushLevelId = (screen, params) => {
 	const collection = collections.get("levels");
@@ -70,7 +73,7 @@ export const config = screen => {
 			},
 		},
 		audio: {
-			group: "topRight",
+			group: gameConfig.vertical ? "topRightV" : "topRight",
 			title: "Sound Off",
 			key: "audio-on",
 			ariaLabel: "Toggle Sound",
@@ -89,7 +92,7 @@ export const config = screen => {
 			},
 		},
 		settings: {
-			group: "topRight",
+			group: gameConfig.vertical ? "topRightV" : "topRight",
 			title: "Settings",
 			key: "settings",
 			ariaLabel: "Game Settings",
@@ -100,7 +103,7 @@ export const config = screen => {
 			},
 		},
 		pause: {
-			group: "topRight",
+			group: gameConfig.vertical ? "topRightV" : "topRight",
 			title: "Pause",
 			key: "pause",
 			ariaLabel: "Pause Game",

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -7,9 +7,6 @@ import { settings, settingsChannel } from "../settings.js";
 import { gmi } from "../gmi/gmi.js";
 import { eventBus } from "../event-bus.js";
 import { collections } from "../../core/collections.js";
-// \---> TODO: find the right place to load game-config
-import gameConfig from "../../../themes/default/game-config.json" assert { type: "json" };
-// <---|
 
 const pushLevelId = (screen, params) => {
 	const collection = collections.get("levels");
@@ -23,6 +20,8 @@ const addChannelToAll = (defaults, channel) => Object.fromEntries(Object.entries
 
 export const buttonsChannel = screen => (screen ? `gel-buttons-${screen.scene.key}` : "gel-buttons");
 export const config = screen => {
+	const { verticalTopRight } = screen?.cache.json.get("game-config") || {};
+
 	const gelDefaults = {
 		exit: {
 			group: "topLeft",
@@ -73,7 +72,7 @@ export const config = screen => {
 			},
 		},
 		audio: {
-			group: gameConfig.vertical ? "topRightV" : "topRight",
+			group: verticalTopRight ? "topRightV" : "topRight",
 			title: "Sound Off",
 			key: "audio-on",
 			ariaLabel: "Toggle Sound",
@@ -92,7 +91,7 @@ export const config = screen => {
 			},
 		},
 		settings: {
-			group: gameConfig.vertical ? "topRightV" : "topRight",
+			group: verticalTopRight ? "topRightV" : "topRight",
 			title: "Settings",
 			key: "settings",
 			ariaLabel: "Game Settings",
@@ -103,7 +102,7 @@ export const config = screen => {
 			},
 		},
 		pause: {
-			group: gameConfig.vertical ? "topRightV" : "topRight",
+			group: verticalTopRight ? "topRightV" : "topRight",
 			title: "Pause",
 			key: "pause",
 			ariaLabel: "Pause Game",

--- a/src/core/layout/gel-group.js
+++ b/src/core/layout/gel-group.js
@@ -63,9 +63,8 @@ export class GelGroup extends Phaser.GameObjects.Container {
 	}
 
 	addButton(config, position = this._buttons.length) {
-		// position = this._isVertical && config.icon ? this._buttons.length : position;
-		// console.log(">>", config.key, config.icon, position);
 		const newButton = createButton(this.scene, config, this.width / 2, this.height / 2);
+		position = this._isVertical ? this._buttons.length - position : position;
 
 		this.addAt(newButton, position);
 		this._buttons.push(newButton);

--- a/src/core/layout/gel-group.js
+++ b/src/core/layout/gel-group.js
@@ -63,6 +63,7 @@ export class GelGroup extends Phaser.GameObjects.Container {
 	}
 
 	addButton(config, position = this._buttons.length) {
+		position = this._isVertical ? 0 : position;
 		const newButton = createButton(this.scene, config, this.width / 2, this.height / 2);
 
 		this.addAt(newButton, position);
@@ -116,7 +117,6 @@ export class GelGroup extends Phaser.GameObjects.Container {
 	}
 
 	alignChildren() {
-		this._isVertical && this.list.reverse();
 		const pos = { x: 0, y: 0 };
 		const groupHeight = Math.max(...this.list.map(i => i.height));
 		const pads = this.list.map(child => Math.max(0, this._metrics.buttonPad - child.width + child.sprite.width));

--- a/src/core/layout/gel-group.js
+++ b/src/core/layout/gel-group.js
@@ -63,7 +63,8 @@ export class GelGroup extends Phaser.GameObjects.Container {
 	}
 
 	addButton(config, position = this._buttons.length) {
-		position = this._isVertical ? 0 : position;
+		// position = this._isVertical && config.icon ? this._buttons.length : position;
+		// console.log(">>", config.key, config.icon, position);
 		const newButton = createButton(this.scene, config, this.width / 2, this.height / 2);
 
 		this.addAt(newButton, position);

--- a/src/core/layout/gel-group.js
+++ b/src/core/layout/gel-group.js
@@ -116,6 +116,7 @@ export class GelGroup extends Phaser.GameObjects.Container {
 	}
 
 	alignChildren() {
+		this._isVertical && this.list.reverse();
 		const pos = { x: 0, y: 0 };
 		const groupHeight = Math.max(...this.list.map(i => i.height));
 		const pads = this.list.map(child => Math.max(0, this._metrics.buttonPad - child.width + child.sprite.width));
@@ -125,7 +126,7 @@ export class GelGroup extends Phaser.GameObjects.Container {
 			this._isVertical &&
 				(pos.y += child.height + Math.max(0, this._metrics.buttonPad - child.height + child.sprite.height));
 			child.x = this._isVertical
-				? 0
+				? child.width / 2
 				: widths.slice(0, idx).reduce(sum, widths[idx] / 2) +
 				  pads.slice(0, idx).reduce(sum, pads[idx] / 2 - pads[0] / 2);
 		}, this);

--- a/src/core/layout/group-layouts.js
+++ b/src/core/layout/group-layouts.js
@@ -6,6 +6,7 @@
 export const groupLayouts = [
 	{ vPos: "top", hPos: "left" },
 	{ vPos: "top", hPos: "right" },
+	{ vPos: "top", hPos: "right", arrangeV: true },
 	{ vPos: "middle", hPos: "left" },
 	{ vPos: "middle", hPos: "left", safe: true },
 	{ vPos: "middle", hPos: "center" },

--- a/src/core/layout/layout.js
+++ b/src/core/layout/layout.js
@@ -43,6 +43,8 @@ const shallowMergeOverrides = (config, overrides) => assignProperties(copyFirstC
  * @param {Array.<string>} accessibleButtonIds
  */
 export function create(scene, metrics, buttonIds, accessibleButtonIds) {
+	const { verticalTopRight } = scene?.cache.json.get("game-config") || {};
+
 	buttonIds = buttonIds.filter(checkGMIFlags);
 	accessibleButtonIds = accessibleButtonIds ? accessibleButtonIds.filter(id => buttonIds.includes(id)) : buttonIds;
 
@@ -83,7 +85,7 @@ export function create(scene, metrics, buttonIds, accessibleButtonIds) {
 	let iconEvents = {};
 
 	if (scene.config.subtitle == undefined) {
-		iconEvents = settingsIcons.create(groups.topRight, buttonIds);
+		iconEvents = settingsIcons.create(verticalTopRight ? groups.topRightV : groups.topRight, buttonIds);
 	}
 
 	/**

--- a/src/core/layout/layout.js
+++ b/src/core/layout/layout.js
@@ -43,7 +43,7 @@ const shallowMergeOverrides = (config, overrides) => assignProperties(copyFirstC
  * @param {Array.<string>} accessibleButtonIds
  */
 export function create(scene, metrics, buttonIds, accessibleButtonIds) {
-	const { verticalTopRight } = scene?.cache.json.get("game-config") || {};
+	const { topRightVertical } = scene?.cache.json.get("config") || {};
 
 	buttonIds = buttonIds.filter(checkGMIFlags);
 	accessibleButtonIds = accessibleButtonIds ? accessibleButtonIds.filter(id => buttonIds.includes(id)) : buttonIds;
@@ -85,7 +85,7 @@ export function create(scene, metrics, buttonIds, accessibleButtonIds) {
 	let iconEvents = {};
 
 	if (scene.config.subtitle == undefined) {
-		iconEvents = settingsIcons.create(verticalTopRight ? groups.topRightV : groups.topRight, buttonIds);
+		iconEvents = settingsIcons.create(topRightVertical ? groups.topRightV : groups.topRight, buttonIds);
 	}
 
 	/**

--- a/src/core/loader/boot.js
+++ b/src/core/loader/boot.js
@@ -39,6 +39,7 @@ export class Boot extends Screen {
 		//TODO P3 this is loaded now so we can check its keys for missing files. It is also loaded again later so perhaps could be done then? NT
 		this.load.json("asset-master-pack", "asset-master-pack.json");
 		this.load.json("font-pack", "fonts.json");
+		this.load.json("game-config", "game-config.json");
 
 		this.setData({
 			parentScreens: [],

--- a/src/core/loader/boot.js
+++ b/src/core/loader/boot.js
@@ -39,7 +39,7 @@ export class Boot extends Screen {
 		//TODO P3 this is loaded now so we can check its keys for missing files. It is also loaded again later so perhaps could be done then? NT
 		this.load.json("asset-master-pack", "asset-master-pack.json");
 		this.load.json("font-pack", "fonts.json");
-		this.load.json("game-config", "game-config.json");
+		this.load.json("config", "config.json");
 
 		this.setData({
 			parentScreens: [],

--- a/test/core/layout/gel-defaults.test.js
+++ b/test/core/layout/gel-defaults.test.js
@@ -38,7 +38,7 @@ describe("Layout - Gel Defaults", () => {
 			},
 			cache: {
 				json: {
-					get: () => ({ verticalTopRight: true }),
+					get: () => ({ topRightVertical: true }),
 				},
 			},
 			context: {

--- a/test/core/layout/gel-defaults.test.js
+++ b/test/core/layout/gel-defaults.test.js
@@ -36,6 +36,11 @@ describe("Layout - Gel Defaults", () => {
 			_data: {
 				addedBy: mockPausedScreen,
 			},
+			cache: {
+				json: {
+					get: () => ({ verticalTopRight: true }),
+				},
+			},
 			context: {
 				navigation: {
 					belowScreenKey: {

--- a/test/core/layout/gel-group.test.js
+++ b/test/core/layout/gel-group.test.js
@@ -254,6 +254,21 @@ describe("Group", () => {
 			});
 		});
 
+		describe("when vPos is top and hPos is right and isVertical is true", () => {
+			test("new buttons are added to position 0", () => {
+				vPos = "top";
+				hPos = "right";
+				group = new GelGroup(mockScene, parentGroup, vPos, hPos, metrics, false, true);
+
+				group.addButton(config);
+				const newButton = mockCreateButton(mockScene);
+				jest.spyOn(CreateButton, "createButton").mockImplementation(() => newButton);
+				group.addButton(config);
+
+				expect(group.addAt).toHaveBeenCalledWith(newButton, 0);
+			});
+		});
+
 		describe("when vPos is bottom and hPos is left", () => {
 			test("sets group position correctly", () => {
 				vPos = "bottom";

--- a/test/core/layout/group-layouts.test.js
+++ b/test/core/layout/group-layouts.test.js
@@ -11,6 +11,7 @@ describe("Group Layouts", () => {
 		const expectedGroupLayouts = [
 			{ vPos: "top", hPos: "left" },
 			{ vPos: "top", hPos: "right" },
+			{ vPos: "top", hPos: "right", arrangeV: true },
 			{ vPos: "middle", hPos: "left" },
 			{ vPos: "middle", hPos: "left", safe: true },
 			{ vPos: "middle", hPos: "center" },

--- a/test/core/layout/layout.test.js
+++ b/test/core/layout/layout.test.js
@@ -44,6 +44,7 @@ describe("Layout", () => {
 		};
 
 		mockJson = {
+			verticalTopRight: false,
 			theme: {
 				mockSceneKey: { "button-overrides": {} },
 			},
@@ -210,6 +211,29 @@ describe("Layout", () => {
 			mockScene.config.subtitle = undefined;
 			Layout.create(mockScene, mockMetrics, ["play"]);
 			expect(settingsIcons.create).toHaveBeenCalledWith(mockGelGroup, ["play"]);
+		});
+
+		test("adds settings icons in the topRight group layout when verticalTopRight config is set false", () => {
+			mockScene.config.subtitle = undefined;
+			const layout = Layout.create(mockScene, mockMetrics, ["settings"]);
+
+			expect(layout.buttons.settings.buttonName.group).toBe("topRight");
+		});
+
+		test("adds settings icons in the topRightV group layout when verticalTopRight config is set true", () => {
+			mockScene.config.subtitle = undefined;
+			mockJson.verticalTopRight = true;
+			const layout = Layout.create(mockScene, mockMetrics, ["settings"]);
+
+			expect(layout.buttons.settings.buttonName.group).toBe("topRightV");
+		});
+
+		test("adds settings icons in the topRightV group layout when verticalTopRight config is not provided", () => {
+			mockScene.config.subtitle = undefined;
+			mockScene.cache.json.get = () => {};
+			const layout = Layout.create(mockScene, mockMetrics, ["settings"]);
+
+			expect(layout.buttons.settings.buttonName.group).toBe("topRight");
 		});
 
 		test("doesn't create the settings icon if there is a subtitle", () => {

--- a/test/core/layout/layout.test.js
+++ b/test/core/layout/layout.test.js
@@ -15,6 +15,7 @@ jest.mock("../../../src/core/layout/gel-group.js");
 
 describe("Layout", () => {
 	const sixGelButtons = ["achievements", "exit", "howToPlay", "play", "audio", "settings"];
+	const expectedNumberOfGroupLayouts = 12;
 
 	let mockGmi;
 	let mockRoot;
@@ -196,7 +197,7 @@ describe("Layout", () => {
 
 		test("resets the groups after they have been added to the layout", () => {
 			Layout.create(mockScene, mockMetrics, []);
-			expect(mockGelGroup.reset).toHaveBeenCalledTimes(11);
+			expect(mockGelGroup.reset).toHaveBeenCalledTimes(expectedNumberOfGroupLayouts);
 			expect(mockGelGroup.reset).toHaveBeenCalledWith(mockMetrics);
 		});
 
@@ -350,7 +351,7 @@ describe("Layout", () => {
 
 			expect(mockGfx.lineStyle).toHaveBeenCalledWith(2, 0x33ff33, 1);
 			expect(mockGfx.strokeRectShape).toHaveBeenCalledWith(mockHitAreaBounds);
-			expect(mockGfx.strokeRectShape).toHaveBeenCalledTimes(11);
+			expect(mockGfx.strokeRectShape).toHaveBeenCalledTimes(expectedNumberOfGroupLayouts);
 		});
 
 		test("draws buttons", () => {
@@ -361,7 +362,7 @@ describe("Layout", () => {
 
 			expect(mockGfx.lineStyle).toHaveBeenCalledWith(1, 0x3333ff, 1);
 			expect(mockGfx.strokeRectShape).toHaveBeenCalledWith(mockHitAreaBounds);
-			expect(mockGfx.strokeRectShape).toHaveBeenCalledTimes(11);
+			expect(mockGfx.strokeRectShape).toHaveBeenCalledTimes(expectedNumberOfGroupLayouts);
 		});
 	});
 });

--- a/test/core/layout/layout.test.js
+++ b/test/core/layout/layout.test.js
@@ -14,8 +14,8 @@ import * as settingsIcons from "../../../src/core/layout/settings-icons.js";
 jest.mock("../../../src/core/layout/gel-group.js");
 
 describe("Layout", () => {
-	const sixGelButtons = ["achievements", "exit", "howToPlay", "play", "audio", "settings"];
-	const expectedNumberOfGroupLayouts = 12;
+	const gelButtons = ["achievements", "exit", "howToPlay", "play", "audio", "settings"];
+	const expectedLayouts = 12;
 
 	let mockGmi;
 	let mockRoot;
@@ -44,7 +44,7 @@ describe("Layout", () => {
 		};
 
 		mockJson = {
-			verticalTopRight: false,
+			topRightVertical: false,
 			theme: {
 				mockSceneKey: { "button-overrides": {} },
 			},
@@ -127,19 +127,19 @@ describe("Layout", () => {
 			const layout2 = Layout.create(mockScene, mockMetrics, ["play", "audio", "settings"]);
 			expect(Object.keys(layout2.buttons).length).toBe(3);
 
-			const layout3 = Layout.create(mockScene, mockMetrics, sixGelButtons);
+			const layout3 = Layout.create(mockScene, mockMetrics, gelButtons);
 			expect(Object.keys(layout3.buttons).length).toBe(6);
 		});
 
 		test("skips the creation of the mute button when gmi.shouldDisplayMuteButton is false", () => {
 			mockGmi.shouldDisplayMuteButton = false;
-			const layout = Layout.create(mockScene, mockMetrics, sixGelButtons);
+			const layout = Layout.create(mockScene, mockMetrics, gelButtons);
 			expect(layout.buttons.audio).not.toBeDefined();
 		});
 
 		test("skips the creation of the exit button when gmi.shouldShowExitButton is false", () => {
 			mockGmi.shouldShowExitButton = false;
-			const layout = Layout.create(mockScene, mockMetrics, sixGelButtons);
+			const layout = Layout.create(mockScene, mockMetrics, gelButtons);
 			expect(layout.buttons.exit).not.toBeDefined();
 		});
 
@@ -153,7 +153,7 @@ describe("Layout", () => {
 				groupLayouts[callNumber].safe,
 				groupLayouts[callNumber].arrangeV,
 			];
-			Layout.create(mockScene, mockMetrics, sixGelButtons);
+			Layout.create(mockScene, mockMetrics, gelButtons);
 			expect(GelGroup).toHaveBeenCalledTimes(groupLayouts.length);
 			GelGroup.mock.calls.forEach((call, index) => {
 				expect(GelGroup.mock.calls[index]).toEqual(getExpectedParams(index));
@@ -198,7 +198,7 @@ describe("Layout", () => {
 
 		test("resets the groups after they have been added to the layout", () => {
 			Layout.create(mockScene, mockMetrics, []);
-			expect(mockGelGroup.reset).toHaveBeenCalledTimes(expectedNumberOfGroupLayouts);
+			expect(mockGelGroup.reset).toHaveBeenCalledTimes(expectedLayouts);
 			expect(mockGelGroup.reset).toHaveBeenCalledWith(mockMetrics);
 		});
 
@@ -213,22 +213,22 @@ describe("Layout", () => {
 			expect(settingsIcons.create).toHaveBeenCalledWith(mockGelGroup, ["play"]);
 		});
 
-		test("adds settings icons in the topRight group layout when verticalTopRight config is set false", () => {
+		test("adds settings icons in the topRight group layout when topRightVertical config is set false", () => {
 			mockScene.config.subtitle = undefined;
 			const layout = Layout.create(mockScene, mockMetrics, ["settings"]);
 
 			expect(layout.buttons.settings.buttonName.group).toBe("topRight");
 		});
 
-		test("adds settings icons in the topRightV group layout when verticalTopRight config is set true", () => {
+		test("adds settings icons in the topRightV group layout when topRightVertical config is set true", () => {
 			mockScene.config.subtitle = undefined;
-			mockJson.verticalTopRight = true;
+			mockJson.topRightVertical = true;
 			const layout = Layout.create(mockScene, mockMetrics, ["settings"]);
 
 			expect(layout.buttons.settings.buttonName.group).toBe("topRightV");
 		});
 
-		test("adds settings icons in the topRightV group layout when verticalTopRight config is not provided", () => {
+		test("adds settings icons in the topRight group layout when topRightVertical config is not provided", () => {
 			mockScene.config.subtitle = undefined;
 			mockScene.cache.json.get = () => {};
 			const layout = Layout.create(mockScene, mockMetrics, ["settings"]);
@@ -245,7 +245,7 @@ describe("Layout", () => {
 
 	describe("addCustomGroup Method", () => {
 		test("returns group", () => {
-			const layout = Layout.create(mockScene, mockMetrics, sixGelButtons);
+			const layout = Layout.create(mockScene, mockMetrics, gelButtons);
 			const key = "test_key";
 			const customGroup = { test_key: "test_value" };
 
@@ -253,7 +253,7 @@ describe("Layout", () => {
 		});
 
 		test("adds custom group to layout", () => {
-			const layout = Layout.create(mockScene, mockMetrics, sixGelButtons);
+			const layout = Layout.create(mockScene, mockMetrics, gelButtons);
 			const key = "test_key";
 			const customGroup = { test_key: "test_value" };
 			layout.addCustomGroup(key, customGroup);
@@ -375,7 +375,7 @@ describe("Layout", () => {
 
 			expect(mockGfx.lineStyle).toHaveBeenCalledWith(2, 0x33ff33, 1);
 			expect(mockGfx.strokeRectShape).toHaveBeenCalledWith(mockHitAreaBounds);
-			expect(mockGfx.strokeRectShape).toHaveBeenCalledTimes(expectedNumberOfGroupLayouts);
+			expect(mockGfx.strokeRectShape).toHaveBeenCalledTimes(expectedLayouts);
 		});
 
 		test("draws buttons", () => {
@@ -386,7 +386,7 @@ describe("Layout", () => {
 
 			expect(mockGfx.lineStyle).toHaveBeenCalledWith(1, 0x3333ff, 1);
 			expect(mockGfx.strokeRectShape).toHaveBeenCalledWith(mockHitAreaBounds);
-			expect(mockGfx.strokeRectShape).toHaveBeenCalledTimes(expectedNumberOfGroupLayouts);
+			expect(mockGfx.strokeRectShape).toHaveBeenCalledTimes(expectedLayouts);
 		});
 	});
 });

--- a/themes/default/config.json
+++ b/themes/default/config.json
@@ -1,0 +1,3 @@
+{
+    "topRightVertical": false
+}

--- a/themes/default/game-config.json
+++ b/themes/default/game-config.json
@@ -1,3 +1,3 @@
 {
-    "vertical": true
+    "verticalTopRight": true
 }

--- a/themes/default/game-config.json
+++ b/themes/default/game-config.json
@@ -1,3 +1,3 @@
 {
-    "verticalTopRight": true
+    "verticalTopRight": false
 }

--- a/themes/default/game-config.json
+++ b/themes/default/game-config.json
@@ -1,3 +1,0 @@
-{
-    "verticalTopRight": false
-}

--- a/themes/default/game-config.json
+++ b/themes/default/game-config.json
@@ -1,0 +1,3 @@
+{
+    "vertical": true
+}


### PR DESCRIPTION
Ticket: https://jira.dev.bbc.co.uk/browse/CGPROD-3891

- added global `game-config` file with a flag for `verticalTopRight` that loads in in `Boot`
- added `topRightV` group layout option
- fixed offset/positioning of top right buttons when vertical layout is selected
- updated/added relating unit tests