### PR TITLE
CGPROD 3891 Slow local dev startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version       | Description                                                                                                                                           |
 |---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+|               | Fix slow start with `npm run start`.                                                                                                                  |
 |               | Fix crash if no levels collection has been defined.                                                                                                   |
 |               | Make loadbarPosY optional.                                                                                                                            |
 |               | Default to GL Mode for Kindles.                                                                                                                       |

--- a/dev/scripts/web-config.js
+++ b/dev/scripts/web-config.js
@@ -10,7 +10,7 @@ const rewrite = [];
 genieCore && rewrite.push({ from: "/node_modules/genie/(.*)", to: "/$1" });
 
 module.exports = {
-	compress: true,
+	compress: false,
 	staticIndex: `${geniePath}dev/index.dev.html`,
 	port: "9000",
 	mime: {


### PR DESCRIPTION
Disable compression (was causing slow starts for local dev when using unbundled ES6 modules)