### PR TITLE
NOTICKET Dom Text Outer Stroke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 | Version       | Description                                                                                                                                           |
 |---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-|               | Update Crel lib and move to npm dependency now it is available as an ES6 module                                                                       |
+|               | Added `addOuterStroke` method to dom text - automatically adds pseudo element hacks to simulate outer stroke.                                         |
+|               | Update Crel lib and move to npm dependency now it is available as an ES6 module.                                                                      |
 |               | Fix slow start with `npm run start`.                                                                                                                  |
 |               | Fix crash if no levels collection has been defined.                                                                                                   |
 |               | Make loadbarPosY optional.                                                                                                                            |

--- a/docs/development/dom-text.md
+++ b/docs/development/dom-text.md
@@ -37,21 +37,29 @@ const domText = this.add.domText("some text\nmore text...", { style, position: {
 Updates the text used e.g:
 ```Javascript
 const domText = this.add.domText("some\n text...");
-getText.setText("Some\nNew\nText");
+domText.setText("Some\nNew\nText");
 ```
 
 ### setPosition
 Updates the text position based as pixel offsets from center fo the screen
 ```Javascript
 const domText = this.add.domText("some\n text...");
-getText.setPosition(100, 200);
+domText.setPosition(100, 200);
 ```
 
 ### setAlignment
 Set the text alignment to either "left", "right" or "center"
 ```Javascript
 const domText = this.add.domText("some\n text...");
-getText.setAlignment("center");
+domText.setAlignment("center");
+```
+
+### addOuterStroke
+Due to the limitations of CSS `stroke` overlapping the edge of text it is not possible to add an outer (usually more pleasing) stroke style. 
+This method creates data elements and attached inline style sheets to apply pseudo `::before` text beneath the existing text and applies the stroke there.
+```Javascript
+const domText = this.add.domText("some\n text...");
+domText.addOuterStroke(2, "black");
 ```
 
 ### setStyle
@@ -59,7 +67,7 @@ Set the CSS style of the text block. Any styles supplied are merged over the exi
 
 ```Javascript
 const domText = this.add.domText("some\n text...");
-getText.setAlignment("center");
+domText.setAlignment("center");
 
 const newStyle = {
             "background-color": "white",
@@ -76,7 +84,7 @@ domText.setStyle(newStyle)
 Removes the text from DOM
 ```Javascript
 const domText = this.add.domText("some\n text...");
-getText.destroy();
+domText.destroy();
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "genie",
-    "version": "3.16.0-pre6",
+    "version": "3.16.0-pre7",
     "description": "BBC Games Genie - A Modular Game Engine",
     "license": "Apache-2.0",
     "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "genie",
-    "version": "3.16.0-pre7",
+    "version": "3.16.0-pre8",
     "description": "BBC Games Genie - A Modular Game Engine",
     "license": "Apache-2.0",
     "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "genie",
-    "version": "3.16.0-pre5",
+    "version": "3.16.0-pre6",
     "description": "BBC Games Genie - A Modular Game Engine",
     "license": "Apache-2.0",
     "private": true,

--- a/src/core/layout/dom-text.js
+++ b/src/core/layout/dom-text.js
@@ -50,6 +50,7 @@ class DomText {
 		  content: attr(data-text);
 		  position: absolute;
 		  left: 0;
+		  top:0;
 		  -webkit-text-stroke: ${size * 2}px ${color};
 		  width: ${this.el.style.width};
 		  z-index:-1;

--- a/src/core/layout/dom-text.js
+++ b/src/core/layout/dom-text.js
@@ -27,17 +27,36 @@ const defaultStyle = {
 const getTextNodes = text => text.split("\n").map(line => document.createTextNode(line));
 const addBreaks = (el, i, arr) => [el].concat(i !== arr.length - 1 ? [document.createElement("br")] : []);
 
+let uid = 0;
+
 class DomText {
 	constructor(text, newConfig) {
 		const config = { ...defaultConfig, ...newConfig };
 		this.el = document.createElement("div");
+		this.el.id = `domtext-${uid++}`;
+		this.el.dataset.text = text;
 		this.setStyle({ ...defaultStyle, ...config.style });
-
 		this._textNodes = [];
 		this.setText(text);
 
 		this.setAlignment(config.align);
 		this.setPosition(config.position.x, config.position.y);
+	}
+
+	addOuterStroke(size, color) {
+		this.inlineStyleSheet = document.createElement("style");
+		const css = `
+		  #${this.el.id}::after {
+		  content: attr(data-text);
+		  position: absolute;
+		  left: 0;
+		  -webkit-text-stroke: ${size * 2}px ${color};
+		  width: ${this.el.style.width};
+		  z-index:-1;
+		  font-size: 1em;
+		}`;
+		this.inlineStyleSheet.appendChild(document.createTextNode(css));
+		gelDom.current().appendChild(this.inlineStyleSheet);
 	}
 
 	setText(newText) {
@@ -63,6 +82,7 @@ class DomText {
 
 	destroy() {
 		this.el.remove();
+		this.inlineStyleSheet?.remove();
 	}
 }
 

--- a/src/core/layout/dom-text.js
+++ b/src/core/layout/dom-text.js
@@ -24,7 +24,7 @@ const defaultStyle = {
 	position: "absolute",
 };
 
-const getTextNodes = text => text.split("\n").map(line => document.createTextNode(line));
+const getTextNodes = text => text.split("\n").map(line => document.createTextNode(line.trim()));
 const addBreaks = (el, i, arr) => [el].concat(i !== arr.length - 1 ? [document.createElement("br")] : []);
 
 let uid = 0;

--- a/test/core/layout/dom-text.test.js
+++ b/test/core/layout/dom-text.test.js
@@ -34,6 +34,12 @@ describe("Gel Text", () => {
 			expect(domText._textNodes[3]).toEqual(document.createElement("br"));
 			expect(domText._textNodes[4]).toEqual(document.createTextNode("line3"));
 		});
+
+		test("Trims lines: Safari miscalculates width of ::after pseudo elements when trailing spaces are present", () => {
+			const domText = addDomText("line1\n  line2  \nline3", {});
+
+			expect(domText._textNodes[2]).toEqual(document.createTextNode("line2"));
+		});
 	});
 
 	describe("GelDom Class Methods", () => {

--- a/test/core/layout/dom-text.test.js
+++ b/test/core/layout/dom-text.test.js
@@ -7,9 +7,12 @@ import { addDomText } from "../../../src/core/layout/dom-text.js";
 import * as gelDomModule from "../../../src/core/layout/gel-dom.js";
 
 describe("Gel Text", () => {
+	let appendChildSpy;
+
 	beforeEach(() => {
+		appendChildSpy = jest.fn();
 		gelDomModule.gelDom = {
-			current: () => ({ appendChild: jest.fn() }),
+			current: () => ({ appendChild: appendChildSpy }),
 		};
 	});
 
@@ -63,6 +66,40 @@ describe("Gel Text", () => {
 			domText.setStyle({ test: "prop" });
 
 			expect(domText.el.style.test).toBe("prop");
+		});
+
+		test("constructor adds a data-text attribute to be used by inline styles later", () => {
+			const domText = addDomText("test", {});
+			expect(domText.el.dataset.text).toBe("test");
+		});
+
+		test("constructor adds a unique incrementing id", () => {
+			const domText1 = addDomText("test", {});
+			const domText2 = addDomText("test", {});
+
+			expect(domText1.el.id).not.toBe(domText2.el.id);
+		});
+
+		test("destroy method removes stylesheet if present", () => {
+			const domText = addDomText("test", {});
+			domText.addOuterStroke(4, "red");
+			domText.inlineStyleSheet.remove = jest.fn();
+
+			domText.destroy();
+
+			expect(domText.inlineStyleSheet.remove).toHaveBeenCalled();
+		});
+
+		test("addOuterStroke method creates an inline stylesheet and adds it to the parent", () => {
+			const domText = addDomText("test", {});
+			domText.addOuterStroke(4, "red");
+			expect(appendChildSpy.mock.calls[1][0].nodeName).toBe("STYLE");
+		});
+
+		test("addOuterStroke method doubles stroke size as only half is visible", () => {
+			const domText = addDomText("test", {});
+			domText.addOuterStroke(4, "red");
+			expect(domText.inlineStyleSheet.innerHTML).toContain("-webkit-text-stroke: 8px red");
 		});
 	});
 });


### PR DESCRIPTION
 Added `addOuterStroke` method to dom text - automatically adds pseudo element hacks to simulate outer stroke.